### PR TITLE
Minor refactoring and cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
 dependencies = [
  "memchr",
  "serde",
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -56,9 +56,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.1.1"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -219,18 +219,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
+checksum = "856b5cb0902c2b6d65d5fd97dfa30f9b70c7538e770b98eab5ed52d8db923e01"
 
 [[package]]
 name = "ignore"
@@ -251,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
  "windows-sys",
@@ -261,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
@@ -377,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -458,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
  "errno",
@@ -592,9 +589,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,11 @@
-use clap::Parser;
 use crate::fs::erdtree::order::Order;
+use clap::Parser;
+use ignore::{WalkBuilder, WalkParallel};
 use std::{
     convert::From,
     path::{Path, PathBuf},
-    usize
+    usize,
 };
-use ignore::{WalkBuilder, WalkParallel};
 
 /// Defines the CLI.
 #[derive(Parser, Debug)]
@@ -20,7 +20,7 @@ pub struct Clargs {
     /// Ignore .gitignore; disabled by default
     #[arg(short, long)]
     pub ignore_git_ignore: bool,
-    
+
     /// Maximum depth to display
     #[arg(short, long, value_name = "NUM")]
     pub max_depth: Option<usize>,
@@ -35,7 +35,7 @@ pub struct Clargs {
 
     /// Whether to show hidden files; disabled by default
     #[arg(short, long)]
-    pub show_hidden: bool
+    pub show_hidden: bool,
 }
 
 impl Clargs {
@@ -50,7 +50,7 @@ impl Clargs {
 
     /// The order used for printing.
     pub fn order(&self) -> Order {
-        self.order.clone()
+        self.order
     }
 
     /// The max depth to print. Note that all directories are fully traversed to compute file

--- a/src/fs/erdtree/mod.rs
+++ b/src/fs/erdtree/mod.rs
@@ -23,11 +23,12 @@ pub static LS_COLORS: OnceCell<LsColors> = OnceCell::new();
 /// Initializes `LS_COLORS` by reading in the `LS_COLORS` environment variable. If it isn't set, a
 /// default determined by `lscolors` crate will be used.
 pub fn init_ls_colors() {
-    LS_COLORS.set(LsColors::from_env().unwrap_or_default()).unwrap();
+    LS_COLORS
+        .set(LsColors::from_env().unwrap_or_default())
+        .unwrap();
 }
 
 /// Grabs a reference to `LS_COLORS`. Panics if not initialized.
 pub fn get_ls_colors() -> &'static LsColors {
     LS_COLORS.get().expect("LS_COLORS not initialized")
 }
-

--- a/src/fs/erdtree/order.rs
+++ b/src/fs/erdtree/order.rs
@@ -1,18 +1,18 @@
+use super::node::Node;
 use clap::ValueEnum;
 use std::cmp::Ordering;
-use super::node::Node;
 
 /// Order in which to print nodes.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum Order {
     /// Sort entries by file name
     Filename,
-    
+
     /// Sort entries by size in descending order
     Size,
 
     /// No sorting
-    None
+    None,
 }
 
 impl Order {
@@ -21,7 +21,7 @@ impl Order {
         match self {
             Self::Filename => Some(Self::name_comparator),
             Self::Size => Some(Self::size_comparator),
-            _ => None
+            _ => None,
         }
     }
 

--- a/src/fs/erdtree/tree/mod.rs
+++ b/src/fs/erdtree/tree/mod.rs
@@ -1,4 +1,5 @@
 use super::order::Order;
+use super::{super::error::Error, node::Node};
 use crossbeam::channel::{self, Sender};
 use ignore::{WalkParallel, WalkState};
 use std::{
@@ -8,25 +9,21 @@ use std::{
     slice::Iter,
     thread,
 };
-use super::{
-    node::Node,
-    super::error::Error
-};
 
 #[cfg(test)]
 mod test;
 
 /// Used for padding between tree branches.
-pub const SEP: &'static str = "   ";
+pub const SEP: &str = "   ";
 
 /// The `│` box drawing character.
-pub const VT: &'static str = "\x1b[35m\u{2502}\x1b[0m  ";
+pub const VT: &str = "\x1b[35m\u{2502}\x1b[0m  ";
 
 /// The `└─` box drawing characters.
-pub const UPRT: &'static str = "\x1b[35m\u{2514}\u{2500}\x1b[0m ";
+pub const UPRT: &str = "\x1b[35m\u{2514}\u{2500}\x1b[0m ";
 
 /// The `├─` box drawing characters.
-pub const VTRT: &'static str = "\x1b[35m\u{251C}\u{2500}\x1b[0m ";
+pub const VTRT: &str = "\x1b[35m\u{251C}\u{2500}\x1b[0m ";
 
 /// In-memory representation of the root-directory and its contents which respects `.gitignore`.
 #[derive(Debug)]
@@ -38,7 +35,7 @@ pub struct Tree {
 }
 
 pub type TreeResult<T> = Result<T, Error>;
-pub type Branches = HashMap::<PathBuf, Vec<Node>>;
+pub type Branches = HashMap<PathBuf, Vec<Node>>;
 pub type TreeComponents = (Node, Branches);
 
 impl Tree {
@@ -46,7 +43,11 @@ impl Tree {
     pub fn new(walker: WalkParallel, order: Order, max_depth: Option<usize>) -> TreeResult<Self> {
         let root = Self::traverse(walker, &order)?;
 
-        Ok(Self { max_depth, order, root })
+        Ok(Self {
+            max_depth,
+            order,
+            root,
+        })
     }
 
     /// Returns a reference to the root [Node].
@@ -82,15 +83,11 @@ impl Tree {
                     }
                 }
 
-                let parent = node
-                    .parent_path_buf()
-                    .ok_or(Error::ExpectedParent)?;
+                let parent = node.parent_path_buf().ok_or(Error::ExpectedParent)?;
 
-                let update = branches
-                    .get_mut(&parent)
-                    .map(|mut_ref| mut_ref.push(node));
+                let update = branches.get_mut(&parent).map(|mut_ref| mut_ref.push(node));
 
-                if let None = update {
+                if update.is_none() {
                     branches.insert(parent, vec![]);
                 }
             }
@@ -102,15 +99,17 @@ impl Tree {
 
         // All filesystem I/O and related system-calls should be relegated to this. Directory
         // entries that are encountered are sent to the above thread for processing.
-        walker.run(|| Box::new(|entry_res| {
-            let tx = Sender::clone(&tx);
+        walker.run(|| {
+            Box::new(|entry_res| {
+                let tx = Sender::clone(&tx);
 
-            entry_res
-                .map(|entry| Node::from(entry)) 
-                .map(|node| tx.send(node).unwrap())
-                .map(|_| WalkState::Continue)
-                .unwrap_or(WalkState::Skip)
-        }));
+                entry_res
+                    .map(Node::from)
+                    .map(|node| tx.send(node).unwrap())
+                    .map(|_| WalkState::Continue)
+                    .unwrap_or(WalkState::Skip)
+            })
+        });
 
         drop(tx);
 
@@ -124,34 +123,32 @@ impl Tree {
     /// Takes the results of the parallel traversal and uses it to construct the [Tree] data
     /// structure. Sorting occurs if specified.
     fn assemble_tree(current_dir: &mut Node, branches: &mut Branches, order: &Order) {
-        let dir_node = branches.remove(current_dir.path())
-            .and_then(|children| {
-                current_dir.set_children(children);
-                Some(current_dir)
-            });
+        let dir_node = branches.remove(current_dir.path()).map(|children| {
+            current_dir.set_children(children);
+            current_dir
+        });
 
         if let Some(node) = dir_node {
             let mut dir_size = 0;
 
-            node.children_mut()
-                .map(|nodes| nodes.iter_mut())
-                .map(|node_iter| {
-                    node_iter.for_each(|node| {
-                        if node.is_dir() {
-                            Self::assemble_tree(node, branches, order);
-                        }
-                        dir_size += node.file_size.unwrap_or(0);
-                    });
+            if let Some(node_iter) = node.children_mut().map(|nodes| nodes.iter_mut()) {
+                node_iter.for_each(|node| {
+                    if node.is_dir() {
+                        Self::assemble_tree(node, branches, order);
+                    }
+                    dir_size += node.file_size.unwrap_or(0);
                 });
+            }
 
-            if dir_size > 0 { node.set_file_size(dir_size) }
+            if dir_size > 0 {
+                node.set_file_size(dir_size)
+            }
 
-            order
-                .comparator()
-                .map(|func| {
-                    node.children_mut()
-                        .map(|nodes| nodes.sort_by(func));
-                });
+            if let Some(func) = order.comparator() {
+                if let Some(nodes) = node.children_mut() {
+                    nodes.sort_by(func)
+                }
+            }
         }
     }
 }
@@ -164,16 +161,21 @@ impl Display for Tree {
 
         #[inline]
         fn extend_output(output: &mut String, node: &Node, prefix: &str) {
-            output.push_str(format!("{}{}\n", prefix, node).as_str());
+            output.push_str(&format!("{prefix}{node}\n"));
         }
 
         #[inline]
-        fn traverse(output: &mut String, children: Iter<Node>, base_prefix: &str, max_depth: usize) {
+        fn traverse(
+            output: &mut String,
+            children: Iter<Node>,
+            base_prefix: &str,
+            max_depth: usize,
+        ) {
             let mut peekable = children.peekable();
 
             loop {
                 if let Some(child) = peekable.next() {
-                    let last_entry =  peekable.peek().is_none();
+                    let last_entry = peekable.peek().is_none();
 
                     let mut prefix = base_prefix.to_owned();
 
@@ -182,10 +184,12 @@ impl Display for Tree {
                     } else {
                         prefix.push_str(VTRT);
                     }
-                    
-                    extend_output(output, child, prefix.as_str());
 
-                    if !child.is_dir() || child.depth + 1 > max_depth { continue }
+                    extend_output(output, child, &prefix);
+
+                    if !child.is_dir() || child.depth + 1 > max_depth {
+                        continue;
+                    }
 
                     let mut new_base = base_prefix.to_owned();
 
@@ -195,9 +199,9 @@ impl Display for Tree {
                         new_base.push_str(VT);
                     }
 
-                    child
-                        .children()
-                        .map(|iter_children| traverse(output, iter_children, new_base.as_str(), max_depth));
+                    if let Some(iter_children) = child.children() {
+                        traverse(output, iter_children, &new_base, max_depth)
+                    }
 
                     continue;
                 }
@@ -206,9 +210,9 @@ impl Display for Tree {
         }
 
         extend_output(&mut output, root, "");
-        root
-            .children()
-            .map(|iter_children| traverse(&mut output, iter_children, "", max_depth));
+        if let Some(iter_children) = root.children() {
+            traverse(&mut output, iter_children, "", max_depth)
+        }
 
         write!(f, "{output}")
     }

--- a/src/fs/erdtree/tree/test.rs
+++ b/src/fs/erdtree/tree/test.rs
@@ -1,6 +1,6 @@
+use super::super::order::Order;
 use crate::fs::erdtree::init_ls_colors;
 use std::io;
-use super::super::order::Order;
 use tempdir::TempDir;
 
 #[test]
@@ -20,7 +20,7 @@ fn test() -> io::Result<()> {
 }
 
 fn test_size(tmp_dir: &TempDir) {
-    let tree = utils::init_tree(&tmp_dir, Order::None);
+    let tree = utils::init_tree(tmp_dir, Order::None);
 
     assert!(
         tree.root().children().is_some(),
@@ -35,9 +35,10 @@ fn test_size(tmp_dir: &TempDir) {
 }
 
 fn test_alphabetical_ordering(tmp_dir: &TempDir) {
-    let tree = utils::init_tree(&tmp_dir, Order::Filename);
+    let tree = utils::init_tree(tmp_dir, Order::Filename);
 
-    let file_names = tree.root()
+    let file_names = tree
+        .root()
         .children()
         .map(|children| {
             children
@@ -60,9 +61,10 @@ fn test_symlink(tmp_dir: &TempDir) -> io::Result<()> {
     let link = tmp_dir.path().join("sym_a");
 
     symlink(target, link)?;
-    let tree = utils::init_tree(&tmp_dir, Order::None);
+    let tree = utils::init_tree(tmp_dir, Order::None);
 
-    let symlink_node = tree.root()
+    let symlink_node = tree
+        .root()
         .children()
         .map(|mut nodes| nodes.find(|node| node.is_symlink()).unwrap())
         .unwrap();
@@ -81,9 +83,10 @@ fn test_symlink(tmp_dir: &TempDir) -> io::Result<()> {
 }
 
 fn test_size_ordering(tmp_dir: &TempDir) {
-    let tree = utils::init_tree(&tmp_dir, Order::Size);
+    let tree = utils::init_tree(tmp_dir, Order::Size);
 
-    let file_names = tree.root()
+    let file_names = tree
+        .root()
         .children()
         .map(|children| {
             children
@@ -103,7 +106,7 @@ pub(super) mod utils {
     use ignore::WalkBuilder;
     use std::{
         fs::{self, File},
-        io::{self, Write}
+        io::{self, Write},
     };
     use tempdir::TempDir;
 
@@ -112,21 +115,22 @@ pub(super) mod utils {
 
         let tmp_dir = TempDir::new(tmp_dir_name)?;
 
-        let the_call_of_cthulhu_path = tmp_dir.path()
-            .join("call_of_cthulhu.txt");
+        let the_call_of_cthulhu_path = tmp_dir.path().join("call_of_cthulhu.txt");
         File::create(the_call_of_cthulhu_path)
             .and_then(|mut f| writeln!(f, "That is not dead which can eternal lie; and with strange aeons even death may die."))?;
 
-        let nested_dir_a = tmp_dir.path()
-            .join("nested_a");
+        let nested_dir_a = tmp_dir.path().join("nested_a");
         fs::create_dir(&nested_dir_a)?;
 
         let nemesis_path = nested_dir_a.join("nemesis.txt");
-        File::create(nemesis_path)
-            .and_then(|mut f| writeln!(f, "where they roll in their horror unheeded, without knowledge or lustre or name."))?;
+        File::create(nemesis_path).and_then(|mut f| {
+            writeln!(
+                f,
+                "where they roll in their horror unheeded, without knowledge or lustre or name."
+            )
+        })?;
 
-        let nested_dir_b = tmp_dir.path()
-            .join("nested_b");
+        let nested_dir_b = tmp_dir.path().join("nested_b");
         fs::create_dir(&nested_dir_b)?;
 
         let nyarlathotep_path = nested_dir_b.join("nyarlathotep.txt");
@@ -137,9 +141,7 @@ pub(super) mod utils {
     }
 
     pub fn init_tree(tmp_dir: &TempDir, order: Order) -> Tree {
-        let walker = WalkBuilder::new(tmp_dir.path())
-            .threads(1)
-            .build_parallel();
+        let walker = WalkBuilder::new(tmp_dir.path()).threads(1).build_parallel();
         Tree::new(walker, order, None).unwrap()
     }
 }

--- a/src/fs/error.rs
+++ b/src/fs/error.rs
@@ -20,4 +20,3 @@ impl Display for Error {
 }
 
 impl StdError for Error {}
-

--- a/src/fs/file_size.rs
+++ b/src/fs/file_size.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Display, Formatter};
 /// prefix.
 #[derive(Debug)]
 pub struct FileSize {
-    bytes: u64
+    bytes: u64,
 }
 
 /// SI prefixes.
@@ -14,7 +14,7 @@ pub enum Prefix {
     Base,
     Kilo,
     Mega,
-    Giga
+    Giga,
 }
 
 impl Display for Prefix {
@@ -41,13 +41,27 @@ impl Display for FileSize {
         let log = fbytes.log(10.0);
 
         let output = if log < 3.0 {
-            Color::BrightCyan.to_ansi_term_color().paint(format!("{:.2} {}", fbytes, Prefix::Base))
-        } else if log >= 3.0 && log < 6.0 {
-            Color::BrightYellow.to_ansi_term_color().paint(format!("{:.2} {}", fbytes / 1_000.0, Prefix::Kilo))
-        } else if log >= 6.0 && log < 9.0 {
-            Color::BrightGreen.to_ansi_term_color().paint(format!("{:.2} {}", fbytes / 1_000_000.0, Prefix::Mega))
+            Color::BrightCyan
+                .to_ansi_term_color()
+                .paint(format!("{:.2} {}", fbytes, Prefix::Base))
+        } else if (3.0..6.0).contains(&log) {
+            Color::BrightYellow.to_ansi_term_color().paint(format!(
+                "{:.2} {}",
+                fbytes / 1_000.0,
+                Prefix::Kilo
+            ))
+        } else if (6.0..9.0).contains(&log) {
+            Color::BrightGreen.to_ansi_term_color().paint(format!(
+                "{:.2} {}",
+                fbytes / 1_000_000.0,
+                Prefix::Mega
+            ))
         } else {
-            Color::BrightRed.to_ansi_term_color().paint(format!("{:.2} {}", fbytes / 1_000_000_000.0, Prefix::Giga))
+            Color::BrightRed.to_ansi_term_color().paint(format!(
+                "{:.2} {}",
+                fbytes / 1_000_000_000.0,
+                Prefix::Giga
+            ))
         };
 
         write!(f, "{output}")
@@ -58,30 +72,39 @@ impl Display for FileSize {
 mod test {
     #[test]
     fn test_file_size_display() {
-        use lscolors::Color;
         use super::FileSize;
+        use lscolors::Color;
 
         let b = FileSize::new(100);
         assert_eq!(
-            format!("{}", b),
-            format!("{}", Color::BrightCyan.to_ansi_term_color().paint("100.00 B"))
+            format!("{b}"),
+            format!(
+                "{}",
+                Color::BrightCyan.to_ansi_term_color().paint("100.00 B")
+            )
         );
 
         let kb = FileSize::new(1_100);
         assert_eq!(
-            format!("{}", kb),
-            format!("{}", Color::BrightYellow.to_ansi_term_color().paint("1.10 KB"))
+            format!("{kb}"),
+            format!(
+                "{}",
+                Color::BrightYellow.to_ansi_term_color().paint("1.10 KB")
+            )
         );
 
         let mb = FileSize::new(1_100_000);
         assert_eq!(
-            format!("{}", mb),
-            format!("{}", Color::BrightGreen.to_ansi_term_color().paint("1.10 MB"))
+            format!("{mb}"),
+            format!(
+                "{}",
+                Color::BrightGreen.to_ansi_term_color().paint("1.10 MB")
+            )
         );
 
         let gb = FileSize::new(1_120_000_000);
         assert_eq!(
-            format!("{}", gb),
+            format!("{gb}"),
             format!("{}", Color::BrightRed.to_ansi_term_color().paint("1.12 GB"))
         );
     }


### PR DESCRIPTION
## Changes made
1. Refactored the code according to `cargo clippy` and fixed some redundant things, such as calling `.as_str()` on the format-macro, when you can instead use `&format!("...")`
2. Ran `cargo update` - https://doc.rust-lang.org/cargo/commands/cargo-update.html
3. Formatted the code to the style defined in rust-analyzer/cargo fmt