### PR TITLE
support auto build binnary with github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,148 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            use-cross: false
+
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-musl
+            use-cross: false
+
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            use-cross: false
+
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-cross: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Set the version
+      id: version
+      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+        target: ${{ matrix.target }}
+
+
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: ${{ matrix.use-cross }}
+        command: build
+        args: --target ${{ matrix.target }} --release --locked
+
+    - name: Strip binary
+      if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
+      run: strip target/${{ matrix.target }}/release/erdtree
+
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/${{ matrix.target }}/release/erdtree
+        asset_name: erdtree-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}
+        tag: ${{ github.ref }}
+  
+  x86_64-pc-windows-msvc:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: false
+          target: x86_64-pc-windows-msvc
+      
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.use-cross }}
+          command: build
+          args: --release --locked
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/release/erdtree.exe
+          asset_name: erdtree-x86_64-pc-windows-msvc.exe
+          tag: ${{ github.ref }}
+    
+
+
+  aarch64-unknown-linux-gnu-:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Set the version
+        id: version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+      
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: aarch64-unknown-linux-gnu
+
+      - uses: uraimo/run-on-arch-action@v2.3.0
+        name: build native modules using another arch
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          githubToken: ${{ github.token }}
+          dockerRunArgs: |
+            --volume "${PWD}:/build"
+            --volume "/home/runner:/home/runner"
+          install: |
+            apt-get update && apt-get install -y gnupg2 && apt-get install curl gcc g++ make -y
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            source "$HOME/.cargo/env"
+          run: |
+            uname -a
+            chmod -R 777 /build
+            source "$HOME/.cargo/env"
+            cargo build --release --locked
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/release/erdtree
+          asset_name: erdtree-${{ steps.version.outputs.VERSION }}-aarch64-unknown-linux-gnu
+          tag: ${{ github.ref }}
+


### PR DESCRIPTION
github actions log: 
[jobs/7093543725](https://github.com/Tlntin/erdtree/actions/runs/4110580480/jobs/7093543725)

release:
[binnary download](https://github.com/Tlntin/erdtree/releases/tag/v1.0.0)

