### PR TITLE
Prepare for v1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 First release.
 
-## [1.0.0] - 2023-02-05
+## [1.0.0] - 2023-02-07
 
 Did a complete rewrite with emphasis on an intuitive interface and performance. Notable changes:
-- Respects `.gitignore`.
+- Respects `.gitignore` and hidden file rules.
 - Parallel filesystem traversal.
 - Completely new CLI. `$ erdtree -h` for usage info.
 - Uses `LS_COLORS` environment variable for file coloring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ First release.
 ## [1.0.0] - 2023-02-07
 
 Did a complete rewrite with emphasis on an intuitive interface and performance. Notable changes:
+- Binary renamed to `et` for brevity.
 - Respects `.gitignore` and hidden file rules.
 - Parallel filesystem traversal.
 - Completely new CLI. `$ erdtree -h` for usage info.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,22 @@ name = "erdtree"
 version = "1.0.0"
 edition = "2021"
 authors = ["Benjamin Nguyen <benjamin.van.nguyen@gmail.com>"]
+description = """
+erdtree is vibrant multi-threaded filetree visualizer and disk usage analyzer
+that respects .gitignore and hidden file rules by default.
+"""
+documentation = "https://github.com/solidiquis/erdtree"
+homepage = "https://github.com/solidiquis/erdtree"
+repository = "https://github.com/solidiquis/erdtree"
+keywords = ["tree", "commandline", "command-line", "du"]
+license = "MIT"
+rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bin]]
+name = "et"
+path = "src/main.rs"
 
 [dependencies]
 ansi_term = "0.12.1"

--- a/README.md
+++ b/README.md
@@ -24,17 +24,16 @@ Arguments:
   [DIR]  Root directory to traverse; defaults to current working directory
 
 Options:
-  -i, --ignore-git-ignore          Ignore .gitignore; disabled by default
-  -m, --max-depth <NUM>            Maximum depth to display
-  -n, --num-threads <NUM_THREADS>  Number of threads to use [default: 4]
-  -o, --order <ORDER>              Sort order to display directory content [default: none] [possible values: filename, size, none]
-  -s, --show-hidden                Whether to show hidden files; disabled by default
-  -g, --glob <GLOB>                Include or exclude files using glob patterns
-      --iglob <GLOB>               Include or exclude files using glob patterns; case insensitive
-      --glob-case-insensitive      Process all glob patterns case insensitively
-  -h, --help                       Print help (see more with '--help')
-  -V, --version                    Print version
-
+  -i, --ignore-git-ignore      Ignore .gitignore; disabled by default
+  -l, --level <NUM>            Maximum depth to display
+  -t, --threads <THREADS>      Number of threads to use [default: 4]
+  -s, --sort <SORT>            Sort-order to display directory content [default: none] [possible values: filename, size, none]
+  -H, --hidden                 Whether to show hidden files; disabled by default
+  -g, --glob <GLOB>            Include or exclude files using glob patterns
+      --iglob <IGLOB>          Include or exclude files using glob patterns; case insensitive
+      --glob-case-insensitive  Process all glob patterns case insensitively
+  -h, --help                   Print help (see more with '--help')
+  -V, --version                Print version
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Erdtree
+# Erdtree (et)
 A modern, vibrant (but not overly), and multi-threaded file-tree visualizer and disk usage analyzer that respects hidden files and `.gitignore` rules - basically if `tree` and `du` had a baby.
 
 <p align="center">
@@ -15,7 +15,7 @@ A modern, vibrant (but not overly), and multi-threaded file-tree visualizer and 
 
 ## Usage
 ```
-$ erdtree -h
+$ et -h
 File tree visualizer and disk usage analyzer.
 
 Usage: erdtree [OPTIONS] [DIR]
@@ -74,9 +74,9 @@ This is not a rewrite of the `tree` command thus it should not be considered a 1
 
 ### Advantages over `exa --tree`
 
-[Exa](https://github.com/ogham/exa) is a powerful modern equivalent of the `ls` command which gives the option to print a tree-view of a specified directory, however the primary differences between `exa --tree` and `erdtree` are:
-- `exa --tree --git-ignore` doesn't respect `.gitignore` rules on a per directory basis whereas `erdtree` does. With `exa` the root's `.gitignore` is considered, but if child directories have their own `.gitignore` they are disregarded and all of their contents will be printed.
-- `erdtree` displays the total size of a directory as the sum of all of its file sizes whereas `exa` [does not support this](https://github.com/ogham/exa/issues/91). This makes sorting directories in the tree-view by size dubious and unclear. Below are screenshots comparing equivalent usages of `erdtree` and `exa`, using long option names for clarity.
+[Exa](https://github.com/ogham/exa) is a powerful modern equivalent of the `ls` command which gives the option to print a tree-view of a specified directory, however the primary differences between `exa --tree` and `et` are:
+- `exa --tree --git-ignore` doesn't respect `.gitignore` rules on a per directory basis whereas `et` does. With `exa` the root's `.gitignore` is considered, but if child directories have their own `.gitignore` they are disregarded and all of their contents will be printed.
+- `et` displays the total size of a directory as the sum of all of its file sizes whereas `exa` [does not support this](https://github.com/ogham/exa/issues/91). This makes sorting directories in the tree-view by size dubious and unclear. Below are screenshots comparing equivalent usages of `et` and `exa`, using long option names for clarity.
 
 #### Exa
 <p align="center">
@@ -92,7 +92,7 @@ This is not a rewrite of the `tree` command thus it should not be considered a 1
 
 Happy to accept contributions but please keep the following in mind:
 - If you're doing some minor refactoring and/or code cleanup feel free to just submit a PR.
-- If you'd like to add a feature and/or make fundamental changes to `erdtree`'s [traverse](https://github.com/solidiquis/erdtree/blob/e7f37d416d6d61b1d62e2200935b4813aaeab461/src/fs/erdtree/tree/mod.rs#L63) algorithm please open up an issue and get my approval first.
+- If you'd like to add a feature and/or make fundamental changes to `et`'s [traverse](https://github.com/solidiquis/erdtree/blob/e7f37d416d6d61b1d62e2200935b4813aaeab461/src/fs/erdtree/tree/mod.rs#L63) algorithm please open up an issue and get my approval first.
 - Feature adds require tests.
 
 Feature requests in the form of issues in general are welcome.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,19 +28,19 @@ pub struct Clargs {
 
     /// Maximum depth to display
     #[arg(short, long, value_name = "NUM")]
-    pub max_depth: Option<usize>,
+    pub level: Option<usize>,
 
     /// Number of threads to use
     #[arg(short, long, default_value_t = 4)]
-    pub num_threads: usize,
+    pub threads: usize,
 
-    /// Sort order to display directory content
+    /// Sort-order to display directory content
     #[arg(short, long, value_enum, default_value_t = Order::None)]
-    order: Order,
+    sort: Order,
 
     /// Whether to show hidden files; disabled by default
-    #[arg(short, long)]
-    pub show_hidden: bool,
+    #[arg(short ='H', long)]
+    pub hidden: bool,
 
     /// Include or exclude files using glob patterns
     #[arg(short, long)]
@@ -65,15 +65,15 @@ impl Clargs {
         }
     }
 
-    /// The order used for printing.
-    pub fn order(&self) -> Order {
-        self.order
+    /// The sort-order used for printing.
+    pub fn sort(&self) -> Order {
+        self.sort
     }
 
     /// The max depth to print. Note that all directories are fully traversed to compute file
     /// sizes; this just determines how much to print.
-    pub fn max_depth(&self) -> Option<usize> {
-        self.max_depth
+    pub fn level(&self) -> Option<usize> {
+        self.level
     }
 
     /// Ignore file overrides.
@@ -109,8 +109,8 @@ impl TryFrom<&Clargs> for WalkParallel {
             .follow_links(false)
             .overrides(clargs.overrides()?)
             .git_ignore(!clargs.ignore_git_ignore)
-            .hidden(!clargs.show_hidden)
-            .threads(clargs.num_threads)
+            .hidden(!clargs.hidden)
+            .threads(clargs.threads)
             .build_parallel())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     erdtree::init_ls_colors();
     let clargs = Clargs::parse();
     let walker = WalkParallel::try_from(&clargs)?;
-    let tree = Tree::new(walker, clargs.order(), clargs.max_depth())?;
+    let tree = Tree::new(walker, clargs.sort(), clargs.level())?;
 
     println!("{tree}");
 

--- a/tests/glob.rs
+++ b/tests/glob.rs
@@ -8,9 +8,9 @@ fn run_cmd(args: &[&str]) -> String {
     cmd.arg("run")
         .arg("--")
         .arg("tests/data")
-        .arg("--num-threads")
+        .arg("--threads")
         .arg("1")
-        .arg("--order")
+        .arg("--sort")
         .arg("filename");
 
     for arg in args {


### PR DESCRIPTION
- Using argument names that are more aligned with tools like `exa`, `rg`, etc..
- Shorten binary name to `et`
- Crate metadata update