### PR TITLE
speed up github action compile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,10 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             use-cross: false
+          
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            use-cross: false
 
     steps:
     - name: Checkout repository
@@ -53,6 +57,17 @@ jobs:
         profile: minimal
         override: true
         target: ${{ matrix.target }}
+    
+    - name: rust cache restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
 
 
     - name: Build
@@ -61,47 +76,23 @@ jobs:
         use-cross: ${{ matrix.use-cross }}
         command: build
         args: --target ${{ matrix.target }} --release --locked
-
-    - name: Strip binary
-      if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
-      run: strip target/${{ matrix.target }}/release/et
-
-    - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/${{ matrix.target }}/release/et
-        asset_name: et-${{GITHUB_REF#*/tags/}}-${{ matrix.target }}
-        tag: ${{ github.ref }}
-  
-  x86_64-pc-windows-msvc:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: false
-          target: x86_64-pc-windows-msvc
-      
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.use-cross }}
-          command: build
-          args: --release --locked
-
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v1-release
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/release/et.exe
-          asset_name: et-x86_64-pc-windows-msvc.exe
-          tag: ${{ github.ref }}
     
+    - name: Upload files (only for Mac/Linux)
+      if: matrix.target != 'x86_64-pc-windows-msvc'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UPLOADTOOL_ISPRERELEASE: true
+      run: |
+        curl -L https://github.com/probonopd/uploadtool/raw/master/upload.sh --output upload.sh
+        mv target/${{ matrix.target }}/release/et et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}
+        bash upload.sh et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}
+    
+    - name: Upload files (only for Windows)
+      if: matrix.target == 'x86_64-pc-windows-msvc'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UPLOADTOOL_ISPRERELEASE: true
+      run: |
+        curl -L https://github.com/probonopd/uploadtool/raw/master/upload.sh --output upload.sh
+        mv target/${{ matrix.target }}/release/et.exe et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.exe
+        bash upload.sh et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.exe

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,14 @@ jobs:
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-musl
             use-cross: false
+          
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            use-cross: true
+
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-musl
+            use-cross: true
 
           - os: macos-latest
             target: x86_64-apple-darwin
@@ -63,7 +71,7 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: target/${{ matrix.target }}/release/et
-        asset_name: et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}
+        asset_name: et-${{GITHUB_REF#*/tags/}}-${{ matrix.target }}
         tag: ${{ github.ref }}
   
   x86_64-pc-windows-msvc:
@@ -97,52 +105,3 @@ jobs:
           asset_name: et-x86_64-pc-windows-msvc.exe
           tag: ${{ github.ref }}
     
-
-
-  aarch64-unknown-linux-gnu-:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: Set the version
-        id: version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-      
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: aarch64-unknown-linux-gnu
-
-      - uses: uraimo/run-on-arch-action@v2.3.0
-        name: build native modules using another arch
-        with:
-          arch: aarch64
-          distro: ubuntu20.04
-          githubToken: ${{ github.token }}
-          dockerRunArgs: |
-            --volume "${PWD}:/build"
-            --volume "/home/runner:/home/runner"
-          install: |
-            apt-get update && apt-get install -y gnupg2 && apt-get install curl gcc g++ make -y
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            source "$HOME/.cargo/env"
-          run: |
-            uname -a
-            chmod -R 777 /build
-            source "$HOME/.cargo/env"
-            cargo build --release --locked
-
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v1-release
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/release/et
-          asset_name: et-${{ steps.version.outputs.VERSION }}-aarch64-unknown-linux-gnu
-          tag: ${{ github.ref }}
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test App With Cache
 
 on:
   workflow_dispatch: {}
+env:
+  TAG_NAME: "v1.0.1"
 
 jobs:
   publish:
@@ -32,6 +34,10 @@ jobs:
 
           - os: macos-latest
             target: aarch64-apple-darwin
+            use-cross: false
+          
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
             use-cross: false
 
     steps:
@@ -71,13 +77,23 @@ jobs:
         command: build
         args: --target ${{ matrix.target }} --release --locked
 
-    - name: Upload binaries to release
+    - name: Upload binaries to release (only for Mac/Linux)
+      if: matrix.os != 'windows-latest'
       uses: svenstaro/upload-release-action@v1-release
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: target/${{ matrix.target }}/release/et
-        asset_name: et-test-${{ matrix.target }}
-        tag: test
+        asset_name: et-${TAG_NAME}-${{ matrix.target }}
+        tag: ${TAG_NAME}
+    
+    - name: Upload binaries to release (only for Windows)
+      if: matrix.os == 'windows-latest'
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/${{ matrix.target }}/release/et.exe
+        asset_name: et-${TAG_NAME}-${{ matrix.target }}.exe
+        tag: ${TAG_NAME}
     
     - name: rust cache store
       uses: actions/cache/save@v3
@@ -90,34 +106,34 @@ jobs:
           src-tauri/target/
         key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
   
-  x86_64-pc-windows-msvc:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+  # x86_64-pc-windows-msvc:
+  #   runs-on: windows-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 1
       
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: false
-          target: x86_64-pc-windows-msvc
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: false
+  #         target: x86_64-pc-windows-msvc
       
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.use-cross }}
-          command: build
-          args: --release --locked
+  #     - name: Build
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         use-cross: ${{ matrix.use-cross }}
+  #         command: build
+  #         args: --release --locked
 
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v1-release
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/release/et.exe
-          asset_name: et-x86_64-pc-windows-msvc.exe
-          tag: ${{ github.ref }}
+  #     - name: Upload binaries to release
+  #       uses: svenstaro/upload-release-action@v1-release
+  #       with:
+  #         repo_token: ${{ secrets.GITHUB_TOKEN }}
+  #         file: target/release/et.exe
+  #         asset_name: et-x86_64-pc-windows-msvc.exe
+  #         tag: ${{ github.ref }}
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: target/${{ matrix.target }}/release/et
-        asset_name: et-${{ GITHUB_REF#*/tags/ }}-${{ matrix.target }}
+        asset_name: et-${{ github.ref }}-${{ matrix.target }}
         tag: ${{ github.ref }}
     
     - name: rust cache store

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,10 +75,6 @@ jobs:
         command: build
         args: --target ${{ matrix.target }} --release --locked
     
-    - name: Set the version
-      id: version
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-    
     - name: Upload files (only for Mac/Linux)
       if: matrix.target != 'x86_64-pc-windows-msvc'
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,8 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: target/${{ matrix.target }}/release/et
-        asset_name: et-${{ github.ref }}-${{ matrix.target }}
-        tag: ${{ github.ref }}
+        asset_name: et-test-${{ matrix.target }}
+        tag: test
     
     - name: rust cache store
       uses: actions/cache/save@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           src-tauri/target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ runner.target }}-${{ hashFiles('**/Cargo.lock') }}
 
 
     - name: Build
@@ -92,7 +92,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           src-tauri/target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ runner.target }}-${{ hashFiles('**/Cargo.lock') }}
   
   x86_64-pc-windows-msvc:
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: target/${{ matrix.target }}/release/et
-        asset_name: et-${{GITHUB_REF#*/tags/}}-${{ matrix.target }}
+        asset_name: et-${{ GITHUB_REF#*/tags/ }}-${{ matrix.target }}
         tag: ${{ github.ref }}
     
     - name: rust cache store

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,127 @@
+name: Test App With Cache
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            use-cross: false
+
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-musl
+            use-cross: false
+          
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            use-cross: true
+
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-musl
+            use-cross: true
+
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            use-cross: false
+
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-cross: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Set the version
+      id: version
+      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+        target: ${{ matrix.target }}
+    
+    - name: rust cache restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          src-tauri/target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: ${{ matrix.use-cross }}
+        command: build
+        args: --target ${{ matrix.target }} --release --locked
+
+    - name: Strip binary
+      if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
+      run: strip target/${{ matrix.target }}/release/et
+
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/${{ matrix.target }}/release/et
+        asset_name: et-${{GITHUB_REF#*/tags/}}-${{ matrix.target }}
+        tag: ${{ github.ref }}
+    
+    - name: rust cache store
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          src-tauri/target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+  
+  x86_64-pc-windows-msvc:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: false
+          target: x86_64-pc-windows-msvc
+      
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.use-cross }}
+          command: build
+          args: --release --locked
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/release/et.exe
+          asset_name: et-x86_64-pc-windows-msvc.exe
+          tag: ${{ github.ref }}
+    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,8 +82,8 @@ jobs:
         UPLOADTOOL_ISPRERELEASE: true
       run: |
         curl -L https://github.com/probonopd/uploadtool/raw/master/upload.sh --output upload.sh
-        mv target/${{ matrix.target }}/release/et et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}
-        bash upload.sh et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}
+        mv target/${{ matrix.target }}/release/et et-${{ matrix.target }}
+        bash upload.sh et-${{ matrix.target }}
     
     - name: Upload files (only for Windows)
       if: matrix.target == 'x86_64-pc-windows-msvc'
@@ -92,8 +92,8 @@ jobs:
         UPLOADTOOL_ISPRERELEASE: true
       run: |
         curl -L https://github.com/probonopd/uploadtool/raw/master/upload.sh --output upload.sh
-        mv target/${{ matrix.target }}/release/et.exe et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.exe
-        bash upload.sh et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.exe
+        mv target/${{ matrix.target }}/release/et.exe et-${{ matrix.target }}.exe
+        bash upload.sh et-${{ matrix.target }}.exe
     
     
     - name: rust cache store

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           src-tauri/target/
-        key: ${{ runner.os }}-cargo-${{ runner.target }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
 
 
     - name: Build
@@ -70,10 +70,6 @@ jobs:
         use-cross: ${{ matrix.use-cross }}
         command: build
         args: --target ${{ matrix.target }} --release --locked
-
-    - name: Strip binary
-      if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
-      run: strip target/${{ matrix.target }}/release/et
 
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v1-release
@@ -92,7 +88,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           src-tauri/target/
-        key: ${{ runner.os }}-cargo-${{ runner.target }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
   
   x86_64-pc-windows-msvc:
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test App With Cache
 
 on:
   workflow_dispatch: {}
-env:
-  TAG_NAME: "v1.0.1"
 
 jobs:
   publish:
@@ -66,7 +64,7 @@ jobs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-          src-tauri/target/
+          target/
         key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
 
 
@@ -76,24 +74,31 @@ jobs:
         use-cross: ${{ matrix.use-cross }}
         command: build
         args: --target ${{ matrix.target }} --release --locked
-
-    - name: Upload binaries to release (only for Mac/Linux)
-      if: matrix.os != 'windows-latest'
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/${{ matrix.target }}/release/et
-        asset_name: et-${TAG_NAME}-${{ matrix.target }}
-        tag: ${TAG_NAME}
     
-    - name: Upload binaries to release (only for Windows)
-      if: matrix.os == 'windows-latest'
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/${{ matrix.target }}/release/et.exe
-        asset_name: et-${TAG_NAME}-${{ matrix.target }}.exe
-        tag: ${TAG_NAME}
+    - name: Set the version
+      id: version
+      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+    
+    - name: Upload files (only for Mac/Linux)
+      if: matrix.target != 'x86_64-pc-windows-msvc'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UPLOADTOOL_ISPRERELEASE: true
+      run: |
+        curl -L https://github.com/probonopd/uploadtool/raw/master/upload.sh --output upload.sh
+        mv target/${{ matrix.target }}/release/et et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}
+        bash upload.sh et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}
+    
+    - name: Upload files (only for Windows)
+      if: matrix.target == 'x86_64-pc-windows-msvc'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UPLOADTOOL_ISPRERELEASE: true
+      run: |
+        curl -L https://github.com/probonopd/uploadtool/raw/master/upload.sh --output upload.sh
+        mv target/${{ matrix.target }}/release/et.exe et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.exe
+        bash upload.sh et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.exe
+    
     
     - name: rust cache store
       uses: actions/cache/save@v3
@@ -103,37 +108,5 @@ jobs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-          src-tauri/target/
+          target/
         key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
-  
-  # x86_64-pc-windows-msvc:
-  #   runs-on: windows-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 1
-      
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: false
-  #         target: x86_64-pc-windows-msvc
-      
-  #     - name: Build
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         use-cross: ${{ matrix.use-cross }}
-  #         command: build
-  #         args: --release --locked
-
-  #     - name: Upload binaries to release
-  #       uses: svenstaro/upload-release-action@v1-release
-  #       with:
-  #         repo_token: ${{ secrets.GITHUB_TOKEN }}
-  #         file: target/release/et.exe
-  #         asset_name: et-x86_64-pc-windows-msvc.exe
-  #         tag: ${{ github.ref }}
-    


### PR DESCRIPTION
## Support manual release test in github actions
1. Change the Docker compilation of aarch64 to cross-platform compilation to speed up compilation.
2. It supports cargo cache and target folder compilation process cache to speed up compilation.

## How to use test action ?
- click Acions
- click Test App With Cache
- click Run workflow.
![image](https://user-images.githubusercontent.com/28218658/217848122-80e42dba-7459-4b15-90c8-8f2f7aa71c1c.png)

## Note:
- The first compilation takes about 7 minutes. After successful compilation, a cache based on the master branch will be generated, so it only takes about 1-3 minutes to compile again.
- When you compile success, go to `Releases`, you will see a tag `Continuous` with pre-release type.
- After you test the compiled product, it is recommended that you delete the test tag, otherwise the compiled result will not be uploaded due to the duplicate name in the next test。
```bash
 git push origin :refs/tags/continuous
```
- **Publish.yaml will automatically use the cache stored in the master branch by test.yaml.
However, it can only use cache instead of generating cache. Because the cache cannot be shared when the tag is different, but the tag branch can use the cache of the master branch.**

## Log
- test action log: https://github.com/Tlntin/erdtree/actions/workflows/test.yml
- publish action log: https://github.com/Tlntin/erdtree/actions/workflows/publish.yml
- cache save: https://github.com/Tlntin/erdtree/actions/caches
- Release result: https://github.com/Tlntin/erdtree/releases/tag/v1.0.0

## Current bugs
Windows cannot read the tag version number, so after you release the official version, rename the binary file of Windows manually and add a version number to it.