### PR TITLE
Icon support

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ pub struct Clargs {
 
     /// Display file icons; disabled by default
     #[arg(long)]
-    pub icon: bool,
+    pub icons: bool,
 
     /// Ignore .gitignore; disabled by default
     #[arg(short, long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,4 @@
-use crate::fs::erdtree::order::Order;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use ignore::{
     overrides::{Override, OverrideBuilder},
     WalkBuilder, WalkParallel,
@@ -39,6 +38,10 @@ pub struct Clargs {
     #[arg(short = 'H', long)]
     pub hidden: bool,
 
+    /// Display file icons; disabled by default
+    #[arg(long)]
+    pub icon: bool,
+
     /// Ignore .gitignore; disabled by default
     #[arg(short, long)]
     pub ignore_git_ignore: bool,
@@ -58,6 +61,19 @@ pub struct Clargs {
     /// Number of threads to use
     #[arg(short, long, default_value_t = 4)]
     pub threads: usize,
+}
+
+/// Order in which to print nodes.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum Order {
+    /// Sort entries by file name
+    Name,
+
+    /// Sort entries by size in descending order
+    Size,
+
+    /// No sorting
+    None,
 }
 
 impl Clargs {
@@ -112,7 +128,8 @@ impl TryFrom<&Clargs> for WalkParallel {
     fn try_from(clargs: &Clargs) -> Result<Self, Self::Error> {
         let root = clargs.dir();
 
-        fs::metadata(root).map_err(|e| Error::DirNotFound(format!("{}: {e}", root.display())))?;
+        fs::metadata(root)
+            .map_err(|e| Error::DirNotFound(format!("{}: {e}", root.display())))?;
 
         Ok(WalkBuilder::new(root)
             .follow_links(clargs.follow_links)

--- a/src/fs/erdtree/mod.rs
+++ b/src/fs/erdtree/mod.rs
@@ -1,4 +1,5 @@
 /// Contains components of the [`Tree`] data structure that derive from [`DirEntry`].
+///
 /// [`Tree`]: tree::Tree
 /// [`DirEntry`]: ignore::DirEntry
 pub mod node;

--- a/src/fs/erdtree/mod.rs
+++ b/src/fs/erdtree/mod.rs
@@ -1,4 +1,6 @@
-/// Contains components of the `Tree` data structure that derive from [ignore::DirEntry].
+/// Contains components of the [`Tree`] data structure that derive from [`DirEntry`].
+/// [`Tree`]: tree::Tree
+/// [`DirEntry`]: ignore::DirEntry
 pub mod node;
 
 /// Ordering operations for printing.

--- a/src/fs/erdtree/node.rs
+++ b/src/fs/erdtree/node.rs
@@ -126,16 +126,18 @@ impl Node {
     fn get_icon(&self) -> Option<String> {
         if !self.show_icon { return None }
 
-        if let Some(icon) = self.path().extension().map(icon_from_ext) {
-            return icon.map(str::to_owned);
+        let s = |i| Some(self.stylize(i));
+
+        if let Some(icon) = self.path().extension().map(icon_from_ext).flatten() {
+            return s(icon)
         }
 
-        if let Some(icon) = self.file_type().map(icon_from_file_type) {
-            return icon.map(|i| self.stylize(i));
+        if let Some(icon) = self.file_type().map(icon_from_file_type).flatten() {
+            return s(icon);
         }
 
         if let Some(icon) = icon_from_file_name(self.file_name()) {
-            return Some(self.stylize(icon));
+            return s(icon);
         }
 
         Some(icons::get_default_icon().to_owned())

--- a/src/fs/erdtree/node.rs
+++ b/src/fs/erdtree/node.rs
@@ -1,7 +1,7 @@
 use super::get_ls_colors;
 use crate::{
     fs::file_size::FileSize,
-    icons::{self, icon_from_ext, icon_from_file_type}
+    icons::{self, icon_from_ext, icon_from_file_name, icon_from_file_type}
 };
 use ansi_term::Style;
 use ignore::DirEntry;
@@ -132,6 +132,10 @@ impl Node {
 
         if let Some(icon) = self.file_type().map(icon_from_file_type) {
             return icon.map(|i| self.stylize(i));
+        }
+
+        if let Some(icon) = icon_from_file_name(self.file_name()) {
+            return Some(self.stylize(icon));
         }
 
         Some(icons::get_default_icon().to_owned())

--- a/src/fs/erdtree/order.rs
+++ b/src/fs/erdtree/order.rs
@@ -1,17 +1,15 @@
+use crate::cli;
 use super::node::Node;
-use clap::ValueEnum;
-use std::cmp::Ordering;
+use std::{
+    convert::From,
+    cmp::Ordering,
+};
 
 /// Order in which to print nodes.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Order {
-    /// Sort entries by file name
     Name,
-
-    /// Sort entries by size in descending order
     Size,
-
-    /// No sorting
     None,
 }
 
@@ -36,5 +34,15 @@ impl Order {
         let b_size = b.file_size.unwrap_or(0);
 
         b_size.cmp(&a_size)
+    }
+}
+
+impl From<cli::Order> for Order {
+    fn from(ord: cli::Order) -> Self {
+        match ord {
+            cli::Order::Name => Order::Name,
+            cli::Order::Size => Order::Size,
+            cli::Order::None => Order::None
+        }
     }
 }

--- a/src/fs/erdtree/tree/mod.rs
+++ b/src/fs/erdtree/tree/mod.rs
@@ -22,6 +22,7 @@ pub mod ui;
 /// hidden file rules depending on [WalkParallel] config.
 #[derive(Debug)]
 pub struct Tree {
+    #[allow(dead_code)]
     icons: bool,
     level: Option<usize>,
     #[allow(dead_code)]
@@ -150,7 +151,7 @@ impl TryFrom<Clargs> for Tree {
     fn try_from(clargs: Clargs) -> Result<Self, Self::Error> {
         let walker = WalkParallel::try_from(&clargs)?;
         let order = Order::from(clargs.sort());
-        let tree = Tree::new(walker, order, clargs.level(), clargs.icon)?;
+        let tree = Tree::new(walker, order, clargs.level(), clargs.icons)?;
         Ok(tree)
     }
 }

--- a/src/fs/error.rs
+++ b/src/fs/error.rs
@@ -1,4 +1,6 @@
+use crate::cli;
 use std::{
+    convert::From,
     error::Error as StdError,
     fmt::{self, Display, Formatter},
 };
@@ -6,6 +8,7 @@ use std::{
 /// Errors that may occur during filesystem traversal.
 #[derive(Debug)]
 pub enum Error {
+    CliError(cli::Error),
     ExpectedParent,
     MissingRoot,
 }
@@ -13,6 +16,7 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
+            Error::CliError(e) => write!(f, "{e}"),
             Error::ExpectedParent => write!(f, "File expected to have parent"),
             Error::MissingRoot => write!(f, "Failed to compute root node"),
         }
@@ -20,3 +24,9 @@ impl Display for Error {
 }
 
 impl StdError for Error {}
+
+impl From<cli::Error> for Error {
+    fn from(e: cli::Error) -> Self {
+        Self::CliError(e)
+    }
+}

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,238 +1,235 @@
 use ansi_term::Color;
 use crate::hash;
-use once_cell::sync::OnceCell;
+use once_cell::sync::Lazy;
 use std::{
     collections::HashMap,
+    ffi::{OsStr, OsString},
     path::Path,
 };
 
-pub static EXT_ICON_MAP: OnceCell<HashMap<&str, String>> = OnceCell::new();
+static EXT_ICON_MAP: Lazy<HashMap<OsString, String>> = Lazy::new(|| {
+    hash!(
+        OsString::from("ai")            => col(185, "\u{e7b4}"),   // 
+        OsString::from("awk")           => col(59, "\u{e795}"),    // 
+        OsString::from("bash")          => col(113, "\u{e795}"),   // 
+        OsString::from("bat")           => col(154, "\u{e615}"),   // 
+        OsString::from("bmp")           => col(140, "\u{e60d}"),   // 
+        OsString::from("cbl")           => col(25, "\u{2699}"),    // ⚙
+        OsString::from("c++")           => col(204, "\u{e61d}"),   // 
+        OsString::from("c")             => col(75, "\u{e61e}"),    // 
+        OsString::from("cc")            => col(204, "\u{e61d}"),   // 
+        OsString::from("cfg")           => col(231, "\u{e7a3}"),   // 
+        OsString::from("cljc")          => col(107, "\u{e768}"),   // 
+        OsString::from("clj")           => col(107, "\u{e768}"),   // 
+        OsString::from("cljd")          => col(67, "\u{e76a}"),    // 
+        OsString::from("cljs")          => col(67, "\u{e76a}"),    // 
+        OsString::from("cmake")         => col(66, "\u{e615}"),    // 
+        OsString::from("cob")           => col(25, "\u{2699}"),    // ⚙
+        OsString::from("cobol")         => col(25, "\u{2699}"),    // ⚙
+        OsString::from("coffee")        => col(185, "\u{e61b}"),   // 
+        OsString::from("conf")          => col(66, "\u{e615}"),    // 
+        OsString::from("config.ru")     => col(52, "\u{e791}"),    // 
+        OsString::from("cp")            => col(67, "\u{e61d}"),    // 
+        OsString::from("cpp")           => col(67, "\u{e61d}"),    // 
+        OsString::from("cpy")           => col(25, "\u{2699}"),    // ⚙
+        OsString::from("cr")            => col(16, "\u{e24f}"),    // 
+        OsString::from("cs")            => col(58, "\u{f81a}"),    // 
+        OsString::from("csh")           => col(59, "\u{e795}"),    // 
+        OsString::from("cson")          => col(185, "\u{e60b}"),   // 
+        OsString::from("css")           => col(39, "\u{e749}"),    // 
+        OsString::from("csv")           => col(113, "\u{f718}"),   // 
+        OsString::from("cxx")           => col(67, "\u{e61d}"),    // 
+        OsString::from("dart")          => col(25, "\u{e798}"),    // 
+        OsString::from("db")            => col(188, "\u{e706}"),   // 
+        OsString::from("d")             => col(64, "\u{e7af}"),    // 
+        OsString::from("desktop")       => col(60, "\u{f108}"),    // 
+        OsString::from("diff")          => col(59, "\u{e728}"),    // 
+        OsString::from("doc")           => col(25, "\u{f72b}"),    // 
+        OsString::from("drl")           => col(217, "\u{e28c}"),   // 
+        OsString::from("dropbox")       => col(27, "\u{e707}"),    // 
+        OsString::from("dump")          => col(188, "\u{e706}"),   // 
+        OsString::from("edn")           => col(67, "\u{e76a}"),    // 
+        OsString::from("eex")           => col(140, "\u{e62d}"),   // 
+        OsString::from("ejs")           => col(185, "\u{e60e}"),   // 
+        OsString::from("elm")           => col(67, "\u{e62c}"),    // 
+        OsString::from("epp")           => col(255, "\u{e631}"),   // 
+        OsString::from("erb")           => col(52, "\u{e60e}"),    // 
+        OsString::from("erl")           => col(132, "\u{e7b1}"),   // 
+        OsString::from("ex")            => col(140, "\u{e62d}"),   // 
+        OsString::from("exs")           => col(140, "\u{e62d}"),   // 
+        OsString::from("f#")            => col(67, "\u{e7a7}"),    // 
+        OsString::from("fish")          => col(59, "\u{e795}"),    // 
+        OsString::from("fnl")           => col(230, "\u{1f31c}"),  // 🌜
+        OsString::from("fs")            => col(67, "\u{e7a7}"),    // 
+        OsString::from("fsi")           => col(67, "\u{e7a7}"),    // 
+        OsString::from("fsscript")      => col(67, "\u{e7a7}"),    // 
+        OsString::from("fsx")           => col(67, "\u{e7a7}"),    // 
+        OsString::from("GNUmakefile")   => col(66, "\u{e779}"),    // 
+        OsString::from("gd")            => col(66, "\u{e615}"),    // 
+        OsString::from("gemspec")       => col(52, "\u{e791}"),    // 
+        OsString::from("gif")           => col(140, "\u{e60d}"),   // 
+        OsString::from("git")           => col(202, "\u{e702}"),   // 
+        OsString::from("glb")           => col(215, "\u{f1b2}"),   // 
+        OsString::from("go")            => col(67, "\u{e627}"),    // 
+        OsString::from("godot")         => col(66, "\u{e7a3}"),    // 
+        OsString::from("gql")           => col(199, "\u{f20e}"),   // 
+        OsString::from("graphql")       => col(199, "\u{f20e}"),   // 
+        OsString::from("haml")          => col(188, "\u{e60e}"),   // 
+        OsString::from("hbs")           => col(208, "\u{e60f}"),   // 
+        OsString::from("h")             => col(140, "\u{f0fd}"),   // 
+        OsString::from("heex")          => col(140, "\u{e62d}"),   // 
+        OsString::from("hh")            => col(140, "\u{f0fd}"),   // 
+        OsString::from("hpp")           => col(140, "\u{f0fd}"),   // 
+        OsString::from("hrl")           => col(132, "\u{e7b1}"),   // 
+        OsString::from("hs")            => col(140, "\u{e61f}"),   // 
+        OsString::from("htm")           => col(166, "\u{e60e}"),   // 
+        OsString::from("html")          => col(202, "\u{e736}"),   // 
+        OsString::from("hxx")           => col(140, "\u{f0fd}"),   // 
+        OsString::from("ico")           => col(185, "\u{e60d}"),   // 
+        OsString::from("import")        => col(231, "\u{f0c6}"),   // 
+        OsString::from("ini")           => col(66, "\u{e615}"),    // 
+        OsString::from("java")          => col(167, "\u{e738}"),   // 
+        OsString::from("jl")            => col(133, "\u{e624}"),   // 
+        OsString::from("jpeg")          => col(140, "\u{e60d}"),   // 
+        OsString::from("jpg")           => col(140, "\u{e60d}"),   // 
+        OsString::from("js")            => col(185, "\u{e60c}"),   // 
+        OsString::from("json5")         => col(185, "\u{fb25}"),   // ﬥ
+        OsString::from("json")          => col(185, "\u{e60b}"),   // 
+        OsString::from("jsx")           => col(67, "\u{e625}"),    // 
+        OsString::from("ksh")           => col(59, "\u{e795}"),    // 
+        OsString::from("kt")            => col(99, "\u{e634}"),    // 
+        OsString::from("kts")           => col(99, "\u{e634}"),    // 
+        OsString::from("leex")          => col(140, "\u{e62d}"),   // 
+        OsString::from("less")          => col(60, "\u{e614}"),    // 
+        OsString::from("lhs")           => col(140, "\u{e61f}"),   // 
+        OsString::from("license")       => col(185, "\u{e60a}"),   // 
+        OsString::from("lock")          => col(250, "\u{f13e}"),   // 
+        OsString::from("log")           => col(255, "\u{f831}"),   // 
+        OsString::from("lua")           => col(74, "\u{e620}"),    // 
+        OsString::from("luau")          => col(74, "\u{e620}"),    // 
+        OsString::from("makefile")      => col(66, "\u{e779}"),    // 
+        OsString::from("markdown")      => col(67, "\u{e609}"),    // 
+        OsString::from("Makefile")      => col(66, "\u{e779}"),    // 
+        OsString::from("material")      => col(132, "\u{f7f4}"),   // 
+        OsString::from("md")            => col(255, "\u{f48a}"),   // 
+        OsString::from("mdx")           => col(67, "\u{f48a}"),    // 
+        OsString::from("mint")          => col(108, "\u{f829}"),   // 
+        OsString::from("mjs")           => col(221, "\u{e60c}"),   // 
+        OsString::from("mk")            => col(66, "\u{e779}"),    // 
+        OsString::from("ml")            => col(173, "\u{3bb}"),    // λ
+        OsString::from("mli")           => col(173, "\u{3bb}"),    // λ
+        OsString::from("mo")            => col(99, "\u{221e}"),    // ∞
+        OsString::from("mustache")      => col(173, "\u{e60f}"),   // 
+        OsString::from("nim")           => col(220, "\u{1f451}"),  // 👑
+        OsString::from("nix")           => col(110, "\u{f313}"),   // 
+        OsString::from("opus")          => col(208, "\u{f722}"),   // 
+        OsString::from("otf")           => col(231, "\u{f031}"),   // 
+        OsString::from("pck")           => col(66, "\u{f487}"),    // 
+        OsString::from("pdf")           => col(124, "\u{f724}"),   // 
+        OsString::from("php")           => col(140, "\u{e608}"),   // 
+        OsString::from("pl")            => col(67, "\u{e769}"),    // 
+        OsString::from("pm")            => col(67, "\u{e769}"),    // 
+        OsString::from("png")           => col(140, "\u{e60d}"),   // 
+        OsString::from("pp")            => col(255, "\u{e631}"),   // 
+        OsString::from("ppt")           => col(167, "\u{f726}"),   // 
+        OsString::from("prisma")        => col(255, "\u{5351}"),   // 卑
+        OsString::from("pro")           => col(179, "\u{e7a1}"),   // 
+        OsString::from("ps1")           => col(69, "\u{f0a0a}"),   // 󰨊
+        OsString::from("psb")           => col(67, "\u{e7b8}"),    // 
+        OsString::from("psd1")          => col(105, "\u{f0a0a}"),  // 󰨊
+        OsString::from("psd")           => col(67, "\u{e7b8}"),    // 
+        OsString::from("psm1")          => col(105, "\u{f0a0a}"),  // 󰨊
+        OsString::from("pyc")           => col(67, "\u{e606}"),    // 
+        OsString::from("py")            => col(61, "\u{e606}"),    // 
+        OsString::from("pyd")           => col(67, "\u{e606}"),    // 
+        OsString::from("pyo")           => col(67, "\u{e606}"),    // 
+        OsString::from("query")         => col(154, "\u{e21c}"),   // 
+        OsString::from("rake")          => col(52, "\u{e791}"),    // 
+        OsString::from("rb")            => col(52, "\u{e791}"),    // 
+        OsString::from("r")             => col(65, "\u{fcd2}"),    // ﳒ
+        OsString::from("rlib")          => col(180, "\u{e7a8}"),   // 
+        OsString::from("rmd")           => col(67, "\u{e609}"),    // 
+        OsString::from("rproj")         => col(65, "\u{9276}"),    // 鉶
+        OsString::from("rs")            => col(180, "\u{e7a8}"),   // 
+        OsString::from("rss")           => col(215, "\u{e619}"),   // 
+        OsString::from("sass")          => col(204, "\u{e603}"),   // 
+        OsString::from("sbt")           => col(167, "\u{e737}"),   // 
+        OsString::from("scala")         => col(167, "\u{e737}"),   // 
+        OsString::from("scm")           => col(16, "\u{fb26}"),    // ﬦ
+        OsString::from("scss")          => col(204, "\u{e603}"),   // 
+        OsString::from("sh")            => col(59, "\u{e795}"),    // 
+        OsString::from("sig")           => col(173, "\u{3bb}"),    // λ
+        OsString::from("slim")          => col(166, "\u{e60e}"),   // 
+        OsString::from("sln")           => col(98, "\u{e70c}"),    // 
+        OsString::from("sml")           => col(173, "\u{3bb}"),    // λ
+        OsString::from("sol")           => col(67, "\u{fcb9}"),    // ﲹ
+        OsString::from("sql")           => col(188, "\u{e706}"),   // 
+        OsString::from("sqlite3")       => col(188, "\u{e706}"),   // 
+        OsString::from("sqlite")        => col(188, "\u{e706}"),   // 
+        OsString::from("styl")          => col(107, "\u{e600}"),   // 
+        OsString::from("sublime")       => col(98, "\u{e7aa}"),    // 
+        OsString::from("suo")           => col(98, "\u{e70c}"),    // 
+        OsString::from("sv")            => col(29, "\u{f85a}"),    // 
+        OsString::from("svelte")        => col(202, "\u{f260}"),   // 
+        OsString::from("svg")           => col(215, "\u{fc1f}"),   // ﰟ
+        OsString::from("svh")           => col(29, "\u{f85a}"),    // 
+        OsString::from("swift")         => col(173, "\u{e755}"),   // 
+        OsString::from("tbc")           => col(67, "\u{fbd1}"),    // ﯑
+        OsString::from("t")             => col(67, "\u{e769}"),    // 
+        OsString::from("tcl")           => col(67, "\u{fbd1}"),    // ﯑
+        OsString::from("terminal")      => col(71, "\u{f489}"),    // 
+        OsString::from("test.js")       => col(173, "\u{e60c}"),   // 
+        OsString::from("tex")           => col(58, "\u{fb68}"),    // ﭨ
+        OsString::from("tf")            => col(57, "\u{e2a6}"),    // 
+        OsString::from("tfvars")        => col(57, "\u{f15b}"),    // 
+        OsString::from("toml")          => col(66, "\u{e615}"),    // 
+        OsString::from("tres")          => col(185, "\u{e706}"),   // 
+        OsString::from("ts")            => col(67, "\u{e628}"),    // 
+        OsString::from("tscn")          => col(140, "\u{f880}"),   // 
+        OsString::from("tsx")           => col(67, "\u{e7ba}"),    // 
+        OsString::from("twig")          => col(107, "\u{e61c}"),   // 
+        OsString::from("txt")           => col(113, "\u{f718}"),   // 
+        OsString::from("vala")          => col(5, "\u{e69e}"),     // 
+        OsString::from("v")             => col(29, "\u{f85a}"),    // 
+        OsString::from("vh")            => col(29, "\u{f85a}"),    // 
+        OsString::from("vhd")           => col(29, "\u{f85a}"),    // 
+        OsString::from("vhdl")          => col(29, "\u{f85a}"),    // 
+        OsString::from("vim")           => col(29, "\u{e62b}"),    // 
+        OsString::from("vue")           => col(107, "\u{fd42}"),   // ﵂
+        OsString::from("wasm")          => col(99, "\u{e6a1}"),    // 
+        OsString::from("webmanifest")   => col(221, "\u{e60b}"),   // 
+        OsString::from("webpack")       => col(67, "\u{fc29}"),    // ﰩ
+        OsString::from("webp")          => col(140, "\u{e60d}"),   // 
+        OsString::from("xcplayground")  => col(173, "\u{e755}"),   // 
+        OsString::from("xls")           => col(23, "\u{f71a}"),    // 
+        OsString::from("xml")           => col(173, "\u{8b39}"),   // 謹
+        OsString::from("xul")           => col(173, "\u{e745}"),   // 
+        OsString::from("yaml")          => col(66, "\u{e615}"),    // 
+        OsString::from("yml")           => col(66, "\u{e615}"),    // 
+        OsString::from("zig")           => col(208, "\u{f0e7}"),   // 
+        OsString::from("zsh")           => col(113, "\u{e795}")    // 
+    )
+});
 
-pub static DEFAULT_ICON: OnceCell<String> = OnceCell::new();
+static DEFAULT_ICON: Lazy<String> = Lazy::new(|| col(66, "\u{f15b}"));
 
-pub fn init_icons() {
-    let default_icon = Color::Fixed(66).paint("\u{f15b}").to_string();
-    DEFAULT_ICON.set(default_icon).unwrap();
-
-    let ext_icon_map = hash!(
-        "ai"            => Color::Fixed(185).paint("\u{e7b4}").to_string(),   // 
-        "awk"           => Color::Fixed(59).paint("\u{e795}").to_string(),    // 
-        "bash"          => Color::Fixed(113).paint("\u{e795}").to_string(),   // 
-        "bat"           => Color::Fixed(154).paint("\u{e615}").to_string(),   // 
-        "bmp"           => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
-        "cbl"           => Color::Fixed(25).paint("\u{2699}").to_string(),    // ⚙
-        "c++"           => Color::Fixed(204).paint("\u{e61d}").to_string(),   // 
-        "c"             => Color::Fixed(75).paint("\u{e61e}").to_string(),    // 
-        "cc"            => Color::Fixed(204).paint("\u{e61d}").to_string(),   // 
-        "cfg"           => Color::Fixed(231).paint("\u{e7a3}").to_string(),   // 
-        "cljc"          => Color::Fixed(107).paint("\u{e768}").to_string(),   // 
-        "clj"           => Color::Fixed(107).paint("\u{e768}").to_string(),   // 
-        "cljd"          => Color::Fixed(67).paint("\u{e76a}").to_string(),    // 
-        "cljs"          => Color::Fixed(67).paint("\u{e76a}").to_string(),    // 
-        "cmake"         => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
-        "cob"           => Color::Fixed(25).paint("\u{2699}").to_string(),    // ⚙
-        "cobol"         => Color::Fixed(25).paint("\u{2699}").to_string(),    // ⚙
-        "coffee"        => Color::Fixed(185).paint("\u{e61b}").to_string(),   // 
-        "conf"          => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
-        "config.ru"     => Color::Fixed(52).paint("\u{e791}").to_string(),    // 
-        "cp"            => Color::Fixed(67).paint("\u{e61d}").to_string(),    // 
-        "cpp"           => Color::Fixed(67).paint("\u{e61d}").to_string(),    // 
-        "cpy"           => Color::Fixed(25).paint("\u{2699}").to_string(),    // ⚙
-        "cr"            => Color::Fixed(16).paint("\u{e24f}").to_string(),    // 
-        "cs"            => Color::Fixed(58).paint("\u{f81a}").to_string(),    // 
-        "csh"           => Color::Fixed(59).paint("\u{e795}").to_string(),    // 
-        "cson"          => Color::Fixed(185).paint("\u{e60b}").to_string(),   // 
-        "css"           => Color::Fixed(39).paint("\u{e749}").to_string(),    // 
-        "csv"           => Color::Fixed(113).paint("\u{f718}").to_string(),   // 
-        "cxx"           => Color::Fixed(67).paint("\u{e61d}").to_string(),    // 
-        "dart"          => Color::Fixed(25).paint("\u{e798}").to_string(),    // 
-        "db"            => Color::Fixed(188).paint("\u{e706}").to_string(),   // 
-        "d"             => Color::Fixed(64).paint("\u{e7af}").to_string(),    // 
-        "desktop"       => Color::Fixed(60).paint("\u{f108}").to_string(),    // 
-        "diff"          => Color::Fixed(59).paint("\u{e728}").to_string(),    // 
-        "doc"           => Color::Fixed(25).paint("\u{f72b}").to_string(),    // 
-        "drl"           => Color::Fixed(217).paint("\u{e28c}").to_string(),   // 
-        "dropbox"       => Color::Fixed(27).paint("\u{e707}").to_string(),    // 
-        "dump"          => Color::Fixed(188).paint("\u{e706}").to_string(),   // 
-        "edn"           => Color::Fixed(67).paint("\u{e76a}").to_string(),    // 
-        "eex"           => Color::Fixed(140).paint("\u{e62d}").to_string(),   // 
-        "ejs"           => Color::Fixed(185).paint("\u{e60e}").to_string(),   // 
-        "elm"           => Color::Fixed(67).paint("\u{e62c}").to_string(),    // 
-        "epp"           => Color::Fixed(255).paint("\u{e631}").to_string(),   // 
-        "erb"           => Color::Fixed(52).paint("\u{e60e}").to_string(),    // 
-        "erl"           => Color::Fixed(132).paint("\u{e7b1}").to_string(),   // 
-        "ex"            => Color::Fixed(140).paint("\u{e62d}").to_string(),   // 
-        "exs"           => Color::Fixed(140).paint("\u{e62d}").to_string(),   // 
-        "f#"            => Color::Fixed(67).paint("\u{e7a7}").to_string(),    // 
-        "fish"          => Color::Fixed(59).paint("\u{e795}").to_string(),    // 
-        "fnl"           => Color::Fixed(230).paint("\u{1f31c}").to_string(),  // 🌜
-        "fs"            => Color::Fixed(67).paint("\u{e7a7}").to_string(),    // 
-        "fsi"           => Color::Fixed(67).paint("\u{e7a7}").to_string(),    // 
-        "fsscript"      => Color::Fixed(67).paint("\u{e7a7}").to_string(),    // 
-        "fsx"           => Color::Fixed(67).paint("\u{e7a7}").to_string(),    // 
-        "GNUmakefile"   => Color::Fixed(66).paint("\u{e779}").to_string(),    // 
-        "gd"            => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
-        "gemspec"       => Color::Fixed(52).paint("\u{e791}").to_string(),    // 
-        "gif"           => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
-        "git"           => Color::Fixed(202).paint("\u{e702}").to_string(),   // 
-        "glb"           => Color::Fixed(215).paint("\u{f1b2}").to_string(),   // 
-        "go"            => Color::Fixed(67).paint("\u{e627}").to_string(),    // 
-        "godot"         => Color::Fixed(66).paint("\u{e7a3}").to_string(),    // 
-        "gql"           => Color::Fixed(199).paint("\u{f20e}").to_string(),   // 
-        "graphql"       => Color::Fixed(199).paint("\u{f20e}").to_string(),   // 
-        "haml"          => Color::Fixed(188).paint("\u{e60e}").to_string(),   // 
-        "hbs"           => Color::Fixed(208).paint("\u{e60f}").to_string(),   // 
-        "h"             => Color::Fixed(140).paint("\u{f0fd}").to_string(),   // 
-        "heex"          => Color::Fixed(140).paint("\u{e62d}").to_string(),   // 
-        "hh"            => Color::Fixed(140).paint("\u{f0fd}").to_string(),   // 
-        "hpp"           => Color::Fixed(140).paint("\u{f0fd}").to_string(),   // 
-        "hrl"           => Color::Fixed(132).paint("\u{e7b1}").to_string(),   // 
-        "hs"            => Color::Fixed(140).paint("\u{e61f}").to_string(),   // 
-        "htm"           => Color::Fixed(166).paint("\u{e60e}").to_string(),   // 
-        "html"          => Color::Fixed(202).paint("\u{e736}").to_string(),   // 
-        "hxx"           => Color::Fixed(140).paint("\u{f0fd}").to_string(),   // 
-        "ico"           => Color::Fixed(185).paint("\u{e60d}").to_string(),   // 
-        "import"        => Color::Fixed(231).paint("\u{f0c6}").to_string(),   // 
-        "ini"           => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
-        "java"          => Color::Fixed(167).paint("\u{e738}").to_string(),   // 
-        "jl"            => Color::Fixed(133).paint("\u{e624}").to_string(),   // 
-        "jpeg"          => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
-        "jpg"           => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
-        "js"            => Color::Fixed(185).paint("\u{e60c}").to_string(),   // 
-        "json5"         => Color::Fixed(185).paint("\u{fb25}").to_string(),   // ﬥ
-        "json"          => Color::Fixed(185).paint("\u{e60b}").to_string(),   // 
-        "jsx"           => Color::Fixed(67).paint("\u{e625}").to_string(),    // 
-        "ksh"           => Color::Fixed(59).paint("\u{e795}").to_string(),    // 
-        "kt"            => Color::Fixed(99).paint("\u{e634}").to_string(),    // 
-        "kts"           => Color::Fixed(99).paint("\u{e634}").to_string(),    // 
-        "leex"          => Color::Fixed(140).paint("\u{e62d}").to_string(),   // 
-        "less"          => Color::Fixed(60).paint("\u{e614}").to_string(),    // 
-        "lhs"           => Color::Fixed(140).paint("\u{e61f}").to_string(),   // 
-        "license"       => Color::Fixed(185).paint("\u{e60a}").to_string(),   // 
-        "lock"          => Color::Fixed(250).paint("\u{f13e}").to_string(),   // 
-        "log"           => Color::Fixed(255).paint("\u{f831}").to_string(),   // 
-        "lua"           => Color::Fixed(74).paint("\u{e620}").to_string(),    // 
-        "luau"          => Color::Fixed(74).paint("\u{e620}").to_string(),    // 
-        "makefile"      => Color::Fixed(66).paint("\u{e779}").to_string(),    // 
-        "markdown"      => Color::Fixed(67).paint("\u{e609}").to_string(),    // 
-        "Makefile"      => Color::Fixed(66).paint("\u{e779}").to_string(),    // 
-        "material"      => Color::Fixed(132).paint("\u{f7f4}").to_string(),   // 
-        "md"            => Color::Fixed(255).paint("\u{f48a}").to_string(),   // 
-        "mdx"           => Color::Fixed(67).paint("\u{f48a}").to_string(),    // 
-        "mint"          => Color::Fixed(108).paint("\u{f829}").to_string(),   // 
-        "mjs"           => Color::Fixed(221).paint("\u{e60c}").to_string(),   // 
-        "mk"            => Color::Fixed(66).paint("\u{e779}").to_string(),    // 
-        "ml"            => Color::Fixed(173).paint("\u{3bb}").to_string(),    // λ
-        "mli"           => Color::Fixed(173).paint("\u{3bb}").to_string(),    // λ
-        "mo"            => Color::Fixed(99).paint("\u{221e}").to_string(),    // ∞
-        "mustache"      => Color::Fixed(173).paint("\u{e60f}").to_string(),   // 
-        "nim"           => Color::Fixed(220).paint("\u{1f451}").to_string(),  // 👑
-        "nix"           => Color::Fixed(110).paint("\u{f313}").to_string(),   // 
-        "opus"          => Color::Fixed(208).paint("\u{f722}").to_string(),   // 
-        "otf"           => Color::Fixed(231).paint("\u{f031}").to_string(),   // 
-        "pck"           => Color::Fixed(66).paint("\u{f487}").to_string(),    // 
-        "pdf"           => Color::Fixed(124).paint("\u{f724}").to_string(),   // 
-        "php"           => Color::Fixed(140).paint("\u{e608}").to_string(),   // 
-        "pl"            => Color::Fixed(67).paint("\u{e769}").to_string(),    // 
-        "pm"            => Color::Fixed(67).paint("\u{e769}").to_string(),    // 
-        "png"           => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
-        "pp"            => Color::Fixed(255).paint("\u{e631}").to_string(),   // 
-        "ppt"           => Color::Fixed(167).paint("\u{f726}").to_string(),   // 
-        "prisma"        => Color::Fixed(255).paint("\u{5351}").to_string(),   // 卑
-        "pro"           => Color::Fixed(179).paint("\u{e7a1}").to_string(),   // 
-        "ps1"           => Color::Fixed(69).paint("\u{f0a0a}").to_string(),   // 󰨊
-        "psb"           => Color::Fixed(67).paint("\u{e7b8}").to_string(),    // 
-        "psd1"          => Color::Fixed(105).paint("\u{f0a0a}").to_string(),  // 󰨊
-        "psd"           => Color::Fixed(67).paint("\u{e7b8}").to_string(),    // 
-        "psm1"          => Color::Fixed(105).paint("\u{f0a0a}").to_string(),  // 󰨊
-        "pyc"           => Color::Fixed(67).paint("\u{e606}").to_string(),    // 
-        "py"            => Color::Fixed(61).paint("\u{e606}").to_string(),    // 
-        "pyd"           => Color::Fixed(67).paint("\u{e606}").to_string(),    // 
-        "pyo"           => Color::Fixed(67).paint("\u{e606}").to_string(),    // 
-        "query"         => Color::Fixed(154).paint("\u{e21c}").to_string(),   // 
-        "rake"          => Color::Fixed(52).paint("\u{e791}").to_string(),    // 
-        "rb"            => Color::Fixed(52).paint("\u{e791}").to_string(),    // 
-        "r"             => Color::Fixed(65).paint("\u{fcd2}").to_string(),    // ﳒ
-        "rlib"          => Color::Fixed(180).paint("\u{e7a8}").to_string(),   // 
-        "rmd"           => Color::Fixed(67).paint("\u{e609}").to_string(),    // 
-        "rproj"         => Color::Fixed(65).paint("\u{9276}").to_string(),    // 鉶
-        "rs"            => Color::Fixed(180).paint("\u{e7a8}").to_string(),   // 
-        "rss"           => Color::Fixed(215).paint("\u{e619}").to_string(),   // 
-        "sass"          => Color::Fixed(204).paint("\u{e603}").to_string(),   // 
-        "sbt"           => Color::Fixed(167).paint("\u{e737}").to_string(),   // 
-        "scala"         => Color::Fixed(167).paint("\u{e737}").to_string(),   // 
-        "scm"           => Color::Fixed(16).paint("\u{fb26}").to_string(),    // ﬦ
-        "scss"          => Color::Fixed(204).paint("\u{e603}").to_string(),   // 
-        "sh"            => Color::Fixed(59).paint("\u{e795}").to_string(),    // 
-        "sig"           => Color::Fixed(173).paint("\u{3bb}").to_string(),    // λ
-        "slim"          => Color::Fixed(166).paint("\u{e60e}").to_string(),   // 
-        "sln"           => Color::Fixed(98).paint("\u{e70c}").to_string(),    // 
-        "sml"           => Color::Fixed(173).paint("\u{3bb}").to_string(),    // λ
-        "sol"           => Color::Fixed(67).paint("\u{fcb9}").to_string(),    // ﲹ
-        "sql"           => Color::Fixed(188).paint("\u{e706}").to_string(),   // 
-        "sqlite3"       => Color::Fixed(188).paint("\u{e706}").to_string(),   // 
-        "sqlite"        => Color::Fixed(188).paint("\u{e706}").to_string(),   // 
-        "styl"          => Color::Fixed(107).paint("\u{e600}").to_string(),   // 
-        "sublime"       => Color::Fixed(98).paint("\u{e7aa}").to_string(),    // 
-        "suo"           => Color::Fixed(98).paint("\u{e70c}").to_string(),    // 
-        "sv"            => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
-        "svelte"        => Color::Fixed(202).paint("\u{f260}").to_string(),   // 
-        "svg"           => Color::Fixed(215).paint("\u{fc1f}").to_string(),   // ﰟ
-        "svh"           => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
-        "swift"         => Color::Fixed(173).paint("\u{e755}").to_string(),   // 
-        "tbc"           => Color::Fixed(67).paint("\u{fbd1}").to_string(),    // ﯑
-        "t"             => Color::Fixed(67).paint("\u{e769}").to_string(),    // 
-        "tcl"           => Color::Fixed(67).paint("\u{fbd1}").to_string(),    // ﯑
-        "terminal"      => Color::Fixed(71).paint("\u{f489}").to_string(),    // 
-        "test.js"       => Color::Fixed(173).paint("\u{e60c}").to_string(),   // 
-        "tex"           => Color::Fixed(58).paint("\u{fb68}").to_string(),    // ﭨ
-        "tf"            => Color::Fixed(57).paint("\u{e2a6}").to_string(),    // 
-        "tfvars"        => Color::Fixed(57).paint("\u{f15b}").to_string(),    // 
-        "toml"          => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
-        "tres"          => Color::Fixed(185).paint("\u{e706}").to_string(),   // 
-        "ts"            => Color::Fixed(67).paint("\u{e628}").to_string(),    // 
-        "tscn"          => Color::Fixed(140).paint("\u{f880}").to_string(),   // 
-        "tsx"           => Color::Fixed(67).paint("\u{e7ba}").to_string(),    // 
-        "twig"          => Color::Fixed(107).paint("\u{e61c}").to_string(),   // 
-        "txt"           => Color::Fixed(113).paint("\u{f718}").to_string(),   // 
-        "vala"          => Color::Fixed(5).paint("\u{e69e}").to_string(),     // 
-        "v"             => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
-        "vh"            => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
-        "vhd"           => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
-        "vhdl"          => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
-        "vim"           => Color::Fixed(29).paint("\u{e62b}").to_string(),    // 
-        "vue"           => Color::Fixed(107).paint("\u{fd42}").to_string(),   // ﵂
-        "wasm"          => Color::Fixed(99).paint("\u{e6a1}").to_string(),    // 
-        "webmanifest"   => Color::Fixed(221).paint("\u{e60b}").to_string(),   // 
-        "webpack"       => Color::Fixed(67).paint("\u{fc29}").to_string(),    // ﰩ
-        "webp"          => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
-        "xcplayground"  => Color::Fixed(173).paint("\u{e755}").to_string(),   // 
-        "xls"           => Color::Fixed(23).paint("\u{f71a}").to_string(),    // 
-        "xml"           => Color::Fixed(173).paint("\u{8b39}").to_string(),   // 謹
-        "xul"           => Color::Fixed(173).paint("\u{e745}").to_string(),   // 
-        "yaml"          => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
-        "yml"           => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
-        "zig"           => Color::Fixed(208).paint("\u{f0e7}").to_string(),   // 
-        "zsh"           => Color::Fixed(113).paint("\u{e795}").to_string()    // 
-    );
-
-    EXT_ICON_MAP.set(ext_icon_map).unwrap();
+pub fn icon(path: &Path) -> &str {
+    path.extension()
+        .map(icon_from_ext)
+        .unwrap_or_else(get_default_icon)
 }
 
-pub fn icon(path: &Path) -> String {
-    path.extension()
-        .map(|os_str| os_str.to_str())
-        .flatten()
-        .map(icon_from_ext)
-        .unwrap_or(DEFAULT_ICON.get().unwrap().to_owned())
+fn get_default_icon<'a>() -> &'a str {
+    DEFAULT_ICON.as_str()
 }
 
 /// Reference: https://github.com/nvim-tree/nvim-web-devicons/blob/master/lua/nvim-web-devicons.lua
-fn icon_from_ext(ext: &str) -> String {
-    EXT_ICON_MAP
-        .get()
-        .map(|icons| icons.get(ext))
-        .flatten()
-        .unwrap_or(DEFAULT_ICON.get().expect("Uninitialized icons"))
-        .to_string()
+fn icon_from_ext(ext: &OsStr) -> &str {
+    EXT_ICON_MAP.get(ext)
+        .map(String::as_str)
+        .unwrap_or_else(get_default_icon)
+}
+
+fn col(num: u8, code: &str) -> String {
+    Color::Fixed(num).paint(code).to_string()
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -4,10 +4,14 @@ use once_cell::sync::Lazy;
 use std::{
     collections::HashMap,
     ffi::{OsStr, OsString},
-    fs::FileType,
-    path::Path,
+    fs::FileType
 };
 
+/// Lazily evaluated static hash-map of special file-types and their corresponding styled icons.
+/// These icons will take on the color properties of their associated file which is based on
+/// `LS_COLORS`.
+///
+/// Dev icons sourced from [`exa`](https://github.com/ogham/exa/blob/master/src/output/icons.rs)
 static FILE_TYPE_ICON_MAP: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     hash!(
         "dir"     => "\u{f413}", // 
@@ -15,6 +19,60 @@ static FILE_TYPE_ICON_MAP: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     )
 });
 
+/// Lazily evaluated static hash-map of special named and their corresponding icons. These icons
+/// will take on the color properties of their associated file which is based on `LS_COLORS`.
+///
+/// Dev icons sourced from [`exa`](https://github.com/ogham/exa/blob/master/src/output/icons.rs)
+static FILE_NAME_ICON_MAP: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
+    hash!(
+        ".Trash"             => "\u{f1f8}", // 
+        ".atom"              => "\u{e764}", // 
+        ".bashprofile"       => "\u{e615}", // 
+        ".bashrc"            => "\u{f489}", // 
+        ".git"               => "\u{f1d3}", // 
+        ".gitattributes"     => "\u{f1d3}", // 
+        ".gitconfig"         => "\u{f1d3}", // 
+        ".github"            => "\u{f408}", // 
+        ".gitignore"         => "\u{f1d3}", // 
+        ".gitmodules"        => "\u{f1d3}", // 
+        ".rvm"               => "\u{e21e}", // 
+        ".vimrc"             => "\u{e62b}", // 
+        ".vscode"            => "\u{e70c}", // 
+        ".zshrc"             => "\u{f489}", // 
+        "Cargo.lock"         => "\u{e7a8}", // 
+        "bin"                => "\u{e5fc}", // 
+        "config"             => "\u{e5fc}", // 
+        "docker-compose.yml" => "\u{f308}", // 
+        "Dockerfile"         => "\u{f308}", // 
+        "ds_store"           => "\u{f179}", // 
+        "gitignore_global"   => "\u{f1d3}", // 
+        "go.mod"             => "\u{e626}", // 
+        "go.sum"             => "\u{e626}", // 
+        "gradle"             => "\u{e256}", // 
+        "gruntfile.coffee"   => "\u{e611}", // 
+        "gruntfile.js"       => "\u{e611}", // 
+        "gruntfile.ls"       => "\u{e611}", // 
+        "gulpfile.coffee"    => "\u{e610}", // 
+        "gulpfile.js"        => "\u{e610}", // 
+        "gulpfile.ls"        => "\u{e610}", // 
+        "hidden"             => "\u{f023}", // 
+        "include"            => "\u{e5fc}", // 
+        "lib"                => "\u{f121}", // 
+        "localized"          => "\u{f179}", // 
+        "Makefile"           => "\u{f489}", // 
+        "node_modules"       => "\u{e718}", // 
+        "npmignore"          => "\u{e71e}", // 
+        "PKGBUILD"           => "\u{f303}", // 
+        "rubydoc"            => "\u{e73b}", // 
+        "yarn.lock"          => "\u{e718}"  // 
+    )
+});
+
+/// Lazily evaluated static hash-map of various file extensions and their corresponding styled
+/// icons. These icons will take on their corresponding file's color properties based on
+/// `LS_COLORS`.
+///
+/// Dev icons and their color palettes sourced from [`nvim-web-devicons`](https://github.com/nvim-tree/nvim-web-devicons/blob/master/lua/nvim-web-devicons.lua).
 static EXT_ICON_MAP: Lazy<HashMap<OsString, String>> = Lazy::new(|| {
     hash!(
         OsString::from("ai")            => col(185, "\u{e7b4}"),   // 
@@ -219,12 +277,15 @@ static EXT_ICON_MAP: Lazy<HashMap<OsString, String>> = Lazy::new(|| {
     )
 });
 
+/// Default fallback icon.
 static DEFAULT_ICON: Lazy<String> = Lazy::new(|| col(66, "\u{f15b}"));
 
+/// Attempts to return an icon given a file extension.
 pub fn icon_from_ext(ext: &OsStr) -> Option<&str> {
     EXT_ICON_MAP.get(ext).map(String::as_str)
 }
 
+/// Attempts to return an icon based on file type.
 pub fn icon_from_file_type(ft: &FileType) -> Option<&str> {
     if ft.is_dir() {
         return FILE_TYPE_ICON_MAP.get("dir").map(|i| *i);
@@ -235,6 +296,11 @@ pub fn icon_from_file_type(ft: &FileType) -> Option<&str> {
     None
 }
 
+pub fn icon_from_file_name(name: &str) -> Option<&str> {
+   FILE_NAME_ICON_MAP.get(name).map(|i| *i)
+}
+
+/// Returns the default fallback icon.
 pub fn get_default_icon<'a>() -> &'a str {
     DEFAULT_ICON.as_str()
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -44,7 +44,7 @@ static FILE_NAME_ICON_MAP: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
         "config"             => "\u{e5fc}", // 
         "docker-compose.yml" => "\u{f308}", // 
         "Dockerfile"         => "\u{f308}", // 
-        "ds_store"           => "\u{f179}", // 
+        ".DS_Store"          => "\u{f179}", // 
         "gitignore_global"   => "\u{f1d3}", // 
         "go.mod"             => "\u{e626}", // 
         "go.sum"             => "\u{e626}", // 
@@ -297,7 +297,7 @@ pub fn icon_from_file_type(ft: &FileType) -> Option<&str> {
 }
 
 pub fn icon_from_file_name(name: &str) -> Option<&str> {
-   FILE_NAME_ICON_MAP.get(name).map(|i| *i)
+    FILE_NAME_ICON_MAP.get(name).map(|i| *i)
 }
 
 /// Returns the default fallback icon.

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,0 +1,238 @@
+use ansi_term::Color;
+use crate::hash;
+use once_cell::sync::OnceCell;
+use std::{
+    collections::HashMap,
+    path::Path,
+};
+
+pub static EXT_ICON_MAP: OnceCell<HashMap<&str, String>> = OnceCell::new();
+
+pub static DEFAULT_ICON: OnceCell<String> = OnceCell::new();
+
+pub fn init_icons() {
+    let default_icon = Color::Fixed(66).paint("\u{f15b}").to_string();
+    DEFAULT_ICON.set(default_icon).unwrap();
+
+    let ext_icon_map = hash!(
+        "ai"            => Color::Fixed(185).paint("\u{e7b4}").to_string(),   // 
+        "awk"           => Color::Fixed(59).paint("\u{e795}").to_string(),    // 
+        "bash"          => Color::Fixed(113).paint("\u{e795}").to_string(),   // 
+        "bat"           => Color::Fixed(154).paint("\u{e615}").to_string(),   // 
+        "bmp"           => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
+        "cbl"           => Color::Fixed(25).paint("\u{2699}").to_string(),    // ⚙
+        "c++"           => Color::Fixed(204).paint("\u{e61d}").to_string(),   // 
+        "c"             => Color::Fixed(75).paint("\u{e61e}").to_string(),    // 
+        "cc"            => Color::Fixed(204).paint("\u{e61d}").to_string(),   // 
+        "cfg"           => Color::Fixed(231).paint("\u{e7a3}").to_string(),   // 
+        "cljc"          => Color::Fixed(107).paint("\u{e768}").to_string(),   // 
+        "clj"           => Color::Fixed(107).paint("\u{e768}").to_string(),   // 
+        "cljd"          => Color::Fixed(67).paint("\u{e76a}").to_string(),    // 
+        "cljs"          => Color::Fixed(67).paint("\u{e76a}").to_string(),    // 
+        "cmake"         => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
+        "cob"           => Color::Fixed(25).paint("\u{2699}").to_string(),    // ⚙
+        "cobol"         => Color::Fixed(25).paint("\u{2699}").to_string(),    // ⚙
+        "coffee"        => Color::Fixed(185).paint("\u{e61b}").to_string(),   // 
+        "conf"          => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
+        "config.ru"     => Color::Fixed(52).paint("\u{e791}").to_string(),    // 
+        "cp"            => Color::Fixed(67).paint("\u{e61d}").to_string(),    // 
+        "cpp"           => Color::Fixed(67).paint("\u{e61d}").to_string(),    // 
+        "cpy"           => Color::Fixed(25).paint("\u{2699}").to_string(),    // ⚙
+        "cr"            => Color::Fixed(16).paint("\u{e24f}").to_string(),    // 
+        "cs"            => Color::Fixed(58).paint("\u{f81a}").to_string(),    // 
+        "csh"           => Color::Fixed(59).paint("\u{e795}").to_string(),    // 
+        "cson"          => Color::Fixed(185).paint("\u{e60b}").to_string(),   // 
+        "css"           => Color::Fixed(39).paint("\u{e749}").to_string(),    // 
+        "csv"           => Color::Fixed(113).paint("\u{f718}").to_string(),   // 
+        "cxx"           => Color::Fixed(67).paint("\u{e61d}").to_string(),    // 
+        "dart"          => Color::Fixed(25).paint("\u{e798}").to_string(),    // 
+        "db"            => Color::Fixed(188).paint("\u{e706}").to_string(),   // 
+        "d"             => Color::Fixed(64).paint("\u{e7af}").to_string(),    // 
+        "desktop"       => Color::Fixed(60).paint("\u{f108}").to_string(),    // 
+        "diff"          => Color::Fixed(59).paint("\u{e728}").to_string(),    // 
+        "doc"           => Color::Fixed(25).paint("\u{f72b}").to_string(),    // 
+        "drl"           => Color::Fixed(217).paint("\u{e28c}").to_string(),   // 
+        "dropbox"       => Color::Fixed(27).paint("\u{e707}").to_string(),    // 
+        "dump"          => Color::Fixed(188).paint("\u{e706}").to_string(),   // 
+        "edn"           => Color::Fixed(67).paint("\u{e76a}").to_string(),    // 
+        "eex"           => Color::Fixed(140).paint("\u{e62d}").to_string(),   // 
+        "ejs"           => Color::Fixed(185).paint("\u{e60e}").to_string(),   // 
+        "elm"           => Color::Fixed(67).paint("\u{e62c}").to_string(),    // 
+        "epp"           => Color::Fixed(255).paint("\u{e631}").to_string(),   // 
+        "erb"           => Color::Fixed(52).paint("\u{e60e}").to_string(),    // 
+        "erl"           => Color::Fixed(132).paint("\u{e7b1}").to_string(),   // 
+        "ex"            => Color::Fixed(140).paint("\u{e62d}").to_string(),   // 
+        "exs"           => Color::Fixed(140).paint("\u{e62d}").to_string(),   // 
+        "f#"            => Color::Fixed(67).paint("\u{e7a7}").to_string(),    // 
+        "fish"          => Color::Fixed(59).paint("\u{e795}").to_string(),    // 
+        "fnl"           => Color::Fixed(230).paint("\u{1f31c}").to_string(),  // 🌜
+        "fs"            => Color::Fixed(67).paint("\u{e7a7}").to_string(),    // 
+        "fsi"           => Color::Fixed(67).paint("\u{e7a7}").to_string(),    // 
+        "fsscript"      => Color::Fixed(67).paint("\u{e7a7}").to_string(),    // 
+        "fsx"           => Color::Fixed(67).paint("\u{e7a7}").to_string(),    // 
+        "GNUmakefile"   => Color::Fixed(66).paint("\u{e779}").to_string(),    // 
+        "gd"            => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
+        "gemspec"       => Color::Fixed(52).paint("\u{e791}").to_string(),    // 
+        "gif"           => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
+        "git"           => Color::Fixed(202).paint("\u{e702}").to_string(),   // 
+        "glb"           => Color::Fixed(215).paint("\u{f1b2}").to_string(),   // 
+        "go"            => Color::Fixed(67).paint("\u{e627}").to_string(),    // 
+        "godot"         => Color::Fixed(66).paint("\u{e7a3}").to_string(),    // 
+        "gql"           => Color::Fixed(199).paint("\u{f20e}").to_string(),   // 
+        "graphql"       => Color::Fixed(199).paint("\u{f20e}").to_string(),   // 
+        "haml"          => Color::Fixed(188).paint("\u{e60e}").to_string(),   // 
+        "hbs"           => Color::Fixed(208).paint("\u{e60f}").to_string(),   // 
+        "h"             => Color::Fixed(140).paint("\u{f0fd}").to_string(),   // 
+        "heex"          => Color::Fixed(140).paint("\u{e62d}").to_string(),   // 
+        "hh"            => Color::Fixed(140).paint("\u{f0fd}").to_string(),   // 
+        "hpp"           => Color::Fixed(140).paint("\u{f0fd}").to_string(),   // 
+        "hrl"           => Color::Fixed(132).paint("\u{e7b1}").to_string(),   // 
+        "hs"            => Color::Fixed(140).paint("\u{e61f}").to_string(),   // 
+        "htm"           => Color::Fixed(166).paint("\u{e60e}").to_string(),   // 
+        "html"          => Color::Fixed(202).paint("\u{e736}").to_string(),   // 
+        "hxx"           => Color::Fixed(140).paint("\u{f0fd}").to_string(),   // 
+        "ico"           => Color::Fixed(185).paint("\u{e60d}").to_string(),   // 
+        "import"        => Color::Fixed(231).paint("\u{f0c6}").to_string(),   // 
+        "ini"           => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
+        "java"          => Color::Fixed(167).paint("\u{e738}").to_string(),   // 
+        "jl"            => Color::Fixed(133).paint("\u{e624}").to_string(),   // 
+        "jpeg"          => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
+        "jpg"           => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
+        "js"            => Color::Fixed(185).paint("\u{e60c}").to_string(),   // 
+        "json5"         => Color::Fixed(185).paint("\u{fb25}").to_string(),   // ﬥ
+        "json"          => Color::Fixed(185).paint("\u{e60b}").to_string(),   // 
+        "jsx"           => Color::Fixed(67).paint("\u{e625}").to_string(),    // 
+        "ksh"           => Color::Fixed(59).paint("\u{e795}").to_string(),    // 
+        "kt"            => Color::Fixed(99).paint("\u{e634}").to_string(),    // 
+        "kts"           => Color::Fixed(99).paint("\u{e634}").to_string(),    // 
+        "leex"          => Color::Fixed(140).paint("\u{e62d}").to_string(),   // 
+        "less"          => Color::Fixed(60).paint("\u{e614}").to_string(),    // 
+        "lhs"           => Color::Fixed(140).paint("\u{e61f}").to_string(),   // 
+        "license"       => Color::Fixed(185).paint("\u{e60a}").to_string(),   // 
+        "lock"          => Color::Fixed(250).paint("\u{f13e}").to_string(),   // 
+        "log"           => Color::Fixed(255).paint("\u{f831}").to_string(),   // 
+        "lua"           => Color::Fixed(74).paint("\u{e620}").to_string(),    // 
+        "luau"          => Color::Fixed(74).paint("\u{e620}").to_string(),    // 
+        "makefile"      => Color::Fixed(66).paint("\u{e779}").to_string(),    // 
+        "markdown"      => Color::Fixed(67).paint("\u{e609}").to_string(),    // 
+        "Makefile"      => Color::Fixed(66).paint("\u{e779}").to_string(),    // 
+        "material"      => Color::Fixed(132).paint("\u{f7f4}").to_string(),   // 
+        "md"            => Color::Fixed(255).paint("\u{f48a}").to_string(),   // 
+        "mdx"           => Color::Fixed(67).paint("\u{f48a}").to_string(),    // 
+        "mint"          => Color::Fixed(108).paint("\u{f829}").to_string(),   // 
+        "mjs"           => Color::Fixed(221).paint("\u{e60c}").to_string(),   // 
+        "mk"            => Color::Fixed(66).paint("\u{e779}").to_string(),    // 
+        "ml"            => Color::Fixed(173).paint("\u{3bb}").to_string(),    // λ
+        "mli"           => Color::Fixed(173).paint("\u{3bb}").to_string(),    // λ
+        "mo"            => Color::Fixed(99).paint("\u{221e}").to_string(),    // ∞
+        "mustache"      => Color::Fixed(173).paint("\u{e60f}").to_string(),   // 
+        "nim"           => Color::Fixed(220).paint("\u{1f451}").to_string(),  // 👑
+        "nix"           => Color::Fixed(110).paint("\u{f313}").to_string(),   // 
+        "opus"          => Color::Fixed(208).paint("\u{f722}").to_string(),   // 
+        "otf"           => Color::Fixed(231).paint("\u{f031}").to_string(),   // 
+        "pck"           => Color::Fixed(66).paint("\u{f487}").to_string(),    // 
+        "pdf"           => Color::Fixed(124).paint("\u{f724}").to_string(),   // 
+        "php"           => Color::Fixed(140).paint("\u{e608}").to_string(),   // 
+        "pl"            => Color::Fixed(67).paint("\u{e769}").to_string(),    // 
+        "pm"            => Color::Fixed(67).paint("\u{e769}").to_string(),    // 
+        "png"           => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
+        "pp"            => Color::Fixed(255).paint("\u{e631}").to_string(),   // 
+        "ppt"           => Color::Fixed(167).paint("\u{f726}").to_string(),   // 
+        "prisma"        => Color::Fixed(255).paint("\u{5351}").to_string(),   // 卑
+        "pro"           => Color::Fixed(179).paint("\u{e7a1}").to_string(),   // 
+        "ps1"           => Color::Fixed(69).paint("\u{f0a0a}").to_string(),   // 󰨊
+        "psb"           => Color::Fixed(67).paint("\u{e7b8}").to_string(),    // 
+        "psd1"          => Color::Fixed(105).paint("\u{f0a0a}").to_string(),  // 󰨊
+        "psd"           => Color::Fixed(67).paint("\u{e7b8}").to_string(),    // 
+        "psm1"          => Color::Fixed(105).paint("\u{f0a0a}").to_string(),  // 󰨊
+        "pyc"           => Color::Fixed(67).paint("\u{e606}").to_string(),    // 
+        "py"            => Color::Fixed(61).paint("\u{e606}").to_string(),    // 
+        "pyd"           => Color::Fixed(67).paint("\u{e606}").to_string(),    // 
+        "pyo"           => Color::Fixed(67).paint("\u{e606}").to_string(),    // 
+        "query"         => Color::Fixed(154).paint("\u{e21c}").to_string(),   // 
+        "rake"          => Color::Fixed(52).paint("\u{e791}").to_string(),    // 
+        "rb"            => Color::Fixed(52).paint("\u{e791}").to_string(),    // 
+        "r"             => Color::Fixed(65).paint("\u{fcd2}").to_string(),    // ﳒ
+        "rlib"          => Color::Fixed(180).paint("\u{e7a8}").to_string(),   // 
+        "rmd"           => Color::Fixed(67).paint("\u{e609}").to_string(),    // 
+        "rproj"         => Color::Fixed(65).paint("\u{9276}").to_string(),    // 鉶
+        "rs"            => Color::Fixed(180).paint("\u{e7a8}").to_string(),   // 
+        "rss"           => Color::Fixed(215).paint("\u{e619}").to_string(),   // 
+        "sass"          => Color::Fixed(204).paint("\u{e603}").to_string(),   // 
+        "sbt"           => Color::Fixed(167).paint("\u{e737}").to_string(),   // 
+        "scala"         => Color::Fixed(167).paint("\u{e737}").to_string(),   // 
+        "scm"           => Color::Fixed(16).paint("\u{fb26}").to_string(),    // ﬦ
+        "scss"          => Color::Fixed(204).paint("\u{e603}").to_string(),   // 
+        "sh"            => Color::Fixed(59).paint("\u{e795}").to_string(),    // 
+        "sig"           => Color::Fixed(173).paint("\u{3bb}").to_string(),    // λ
+        "slim"          => Color::Fixed(166).paint("\u{e60e}").to_string(),   // 
+        "sln"           => Color::Fixed(98).paint("\u{e70c}").to_string(),    // 
+        "sml"           => Color::Fixed(173).paint("\u{3bb}").to_string(),    // λ
+        "sol"           => Color::Fixed(67).paint("\u{fcb9}").to_string(),    // ﲹ
+        "sql"           => Color::Fixed(188).paint("\u{e706}").to_string(),   // 
+        "sqlite3"       => Color::Fixed(188).paint("\u{e706}").to_string(),   // 
+        "sqlite"        => Color::Fixed(188).paint("\u{e706}").to_string(),   // 
+        "styl"          => Color::Fixed(107).paint("\u{e600}").to_string(),   // 
+        "sublime"       => Color::Fixed(98).paint("\u{e7aa}").to_string(),    // 
+        "suo"           => Color::Fixed(98).paint("\u{e70c}").to_string(),    // 
+        "sv"            => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
+        "svelte"        => Color::Fixed(202).paint("\u{f260}").to_string(),   // 
+        "svg"           => Color::Fixed(215).paint("\u{fc1f}").to_string(),   // ﰟ
+        "svh"           => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
+        "swift"         => Color::Fixed(173).paint("\u{e755}").to_string(),   // 
+        "tbc"           => Color::Fixed(67).paint("\u{fbd1}").to_string(),    // ﯑
+        "t"             => Color::Fixed(67).paint("\u{e769}").to_string(),    // 
+        "tcl"           => Color::Fixed(67).paint("\u{fbd1}").to_string(),    // ﯑
+        "terminal"      => Color::Fixed(71).paint("\u{f489}").to_string(),    // 
+        "test.js"       => Color::Fixed(173).paint("\u{e60c}").to_string(),   // 
+        "tex"           => Color::Fixed(58).paint("\u{fb68}").to_string(),    // ﭨ
+        "tf"            => Color::Fixed(57).paint("\u{e2a6}").to_string(),    // 
+        "tfvars"        => Color::Fixed(57).paint("\u{f15b}").to_string(),    // 
+        "toml"          => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
+        "tres"          => Color::Fixed(185).paint("\u{e706}").to_string(),   // 
+        "ts"            => Color::Fixed(67).paint("\u{e628}").to_string(),    // 
+        "tscn"          => Color::Fixed(140).paint("\u{f880}").to_string(),   // 
+        "tsx"           => Color::Fixed(67).paint("\u{e7ba}").to_string(),    // 
+        "twig"          => Color::Fixed(107).paint("\u{e61c}").to_string(),   // 
+        "txt"           => Color::Fixed(113).paint("\u{f718}").to_string(),   // 
+        "vala"          => Color::Fixed(5).paint("\u{e69e}").to_string(),     // 
+        "v"             => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
+        "vh"            => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
+        "vhd"           => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
+        "vhdl"          => Color::Fixed(29).paint("\u{f85a}").to_string(),    // 
+        "vim"           => Color::Fixed(29).paint("\u{e62b}").to_string(),    // 
+        "vue"           => Color::Fixed(107).paint("\u{fd42}").to_string(),   // ﵂
+        "wasm"          => Color::Fixed(99).paint("\u{e6a1}").to_string(),    // 
+        "webmanifest"   => Color::Fixed(221).paint("\u{e60b}").to_string(),   // 
+        "webpack"       => Color::Fixed(67).paint("\u{fc29}").to_string(),    // ﰩ
+        "webp"          => Color::Fixed(140).paint("\u{e60d}").to_string(),   // 
+        "xcplayground"  => Color::Fixed(173).paint("\u{e755}").to_string(),   // 
+        "xls"           => Color::Fixed(23).paint("\u{f71a}").to_string(),    // 
+        "xml"           => Color::Fixed(173).paint("\u{8b39}").to_string(),   // 謹
+        "xul"           => Color::Fixed(173).paint("\u{e745}").to_string(),   // 
+        "yaml"          => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
+        "yml"           => Color::Fixed(66).paint("\u{e615}").to_string(),    // 
+        "zig"           => Color::Fixed(208).paint("\u{f0e7}").to_string(),   // 
+        "zsh"           => Color::Fixed(113).paint("\u{e795}").to_string()    // 
+    );
+
+    EXT_ICON_MAP.set(ext_icon_map).unwrap();
+}
+
+pub fn icon(path: &Path) -> String {
+    path.extension()
+        .map(|os_str| os_str.to_str())
+        .flatten()
+        .map(icon_from_ext)
+        .unwrap_or(DEFAULT_ICON.get().unwrap().to_owned())
+}
+
+/// Reference: https://github.com/nvim-tree/nvim-web-devicons/blob/master/lua/nvim-web-devicons.lua
+fn icon_from_ext(ext: &str) -> String {
+    EXT_ICON_MAP
+        .get()
+        .map(|icons| icons.get(ext))
+        .flatten()
+        .unwrap_or(DEFAULT_ICON.get().expect("Uninitialized icons"))
+        .to_string()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use std::process::ExitCode;
 use clap::Parser;
 use cli::Clargs;
 use fs::erdtree::{self, tree::Tree};
-use ignore::WalkParallel;
 
 /// CLI rules and definitions.
 mod cli;
@@ -26,12 +25,10 @@ fn main() -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn run() -> Result<(), Box<dyn std::error::Error>> {
-    icons::init_icons();
+fn run() -> Result<(), fs::error::Error> {
     erdtree::tree::ui::init();
     let clargs = Clargs::parse();
-    let walker = WalkParallel::try_from(&clargs)?;
-    let tree = Tree::new(walker, clargs.sort(), clargs.level())?;
+    let tree = Tree::try_from(clargs)?;
 
     println!("{tree}");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ mod cli;
 /// Filesystem operations.
 mod fs;
 
-/// Dev icons. Reference: https://github.com/nvim-tree/nvim-web-devicons/blob/master/lua/nvim-web-devicons.lua
+/// Dev icons.
 mod icons;
 
 /// Common utilities.

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ mod cli;
 /// Filesystem operations.
 mod fs;
 
-/// Dev icons.
+/// Dev icons. Reference: https://github.com/nvim-tree/nvim-web-devicons/blob/master/lua/nvim-web-devicons.lua
 mod icons;
 
 /// Common utilities.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ mod cli;
 /// Filesystem operations.
 mod fs;
 
+/// Dev icons.
+mod icons;
+
 /// Common utilities.
 mod utils;
 
@@ -24,6 +27,7 @@ fn main() -> ExitCode {
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
+    icons::init_icons();
     erdtree::tree::ui::init();
     let clargs = Clargs::parse();
     let walker = WalkParallel::try_from(&clargs)?;


### PR DESCRIPTION
<img width="1067" alt="Screen Shot 2023-02-27 at 8 56 03 AM" src="https://user-images.githubusercontent.com/45523555/221631613-76b5e3a9-c827-4ce0-b2f2-63beb544904b.png">

### Highlights
- Added support for the display of glyphs/icons based on file extensions, special file names (e.g. `.Trash`, `.gitignore`, etc.), and a limited subset of file types.
- Icons are enabled with the `--icons` flag similar to how `exa` does it.
- Some icons were sourced from [exa](https://github.com/ogham/exa/blob/master/src/output/icons.rs) and others along  from [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons).
- A color palette for icons of files with common extensions was also sourced from [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons); for icons of files not falling under this category said icons will be styled based on the `LS_COLORS` configuration of its associated file.

### Important

In order for glyphs/icons to display properly your terminal emulator must be configured to use a font that actually contains the glyphs/icons. For a comprehensive list of fonts that's incredibly likely to contain all of the relevant fonts/glyphs, checkout the [Nerd Fonts Project](https://www.nerdfonts.com/).

I personally use [Sauce Code Pro](https://github.com/solidiquis/dotfiles/blob/7ed16ddc202742f109888a3c6addb0320f98de26/alacritty/alacritty.yml#L31)