### PR TITLE
fix extra whitespace problem when displaying symlink name

### DIFF
--- a/src/fs/erdtree/node.rs
+++ b/src/fs/erdtree/node.rs
@@ -172,6 +172,7 @@ impl Node {
             .or_else(|| Some(entity.to_string()))
     }
 
+    /// Stylizes symlink name for display.
     fn stylize_link_name(&self) -> Option<String> {
         self.symlink_target_file_name()
             .map(|name| {
@@ -182,12 +183,14 @@ impl Node {
     }
 }
 
+/// Used to be converted directly into a [Node].
 pub struct NodePrecursor {
     dir_entry: DirEntry,
     show_icon: bool,
 }
 
 impl NodePrecursor {
+    /// Yields a [NodePrecursor] which is used for convenient conversion into a [Node].
     pub fn new(dir_entry: DirEntry, show_icon: bool) -> Self {
         Self { dir_entry, show_icon }
     }

--- a/src/fs/erdtree/node.rs
+++ b/src/fs/erdtree/node.rs
@@ -257,20 +257,31 @@ impl Display for Node {
             .flatten()
             .unwrap_or("".to_owned());
 
-        let styled_name = self.stylize_link_name().unwrap_or_else(|| {
-            self.file_name()
-                .to_str()
-                .map(|name| self.stylize(name))
-                .flatten()
-                .unwrap()
-        });
+        let icon_padding = (icon.len() > 1).then(|| icon.len() - 1).unwrap_or(0);
+
+        let (styled_name, name_padding) = self.stylize_link_name()
+            .map(|name| {
+                let padding = name.len() - 1;
+                (name, padding)
+            })
+            .or_else(|| {
+                let name = self.file_name()
+                    .to_str()
+                    .map(|name| self.stylize(name))
+                    .flatten()
+                    .unwrap();
+                let padding = name.len() + 1;
+
+                Some((name, padding))
+            })
+            .unwrap();
 
         let output = format!(
             "{:<icon_padding$}{:<name_padding$}{size}",
              icon,
              styled_name,
-             icon_padding = (icon.len() > 1).then(|| icon.len() - 1).unwrap_or(0),
-             name_padding = styled_name.len() + 1
+             icon_padding = icon_padding,
+             name_padding = name_padding
          );
 
         write!(f, "{output}")

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -301,6 +301,7 @@ pub fn icon_from_file_type(ft: &FileType) -> Option<&str> {
     None
 }
 
+/// Attempts to get the icon associated with the special file kind.
 pub fn icon_from_file_name(name: &OsStr) -> Option<&str> {
     FILE_NAME_ICON_MAP.get(name).map(|i| *i)
 }
@@ -310,6 +311,7 @@ pub fn get_default_icon<'a>() -> &'a str {
     DEFAULT_ICON.as_str()
 }
 
+/// Convenience method to paint fixed colors.
 fn col(num: u8, code: &str) -> String {
     Color::Fixed(num).paint(code).to_string()
 }


### PR DESCRIPTION
Fix issue where there's extra fill to the left of the disk usage of symlinks.
<img width="406" alt="Screen Shot 2023-03-04 at 12 35 19 PM" src="https://user-images.githubusercontent.com/45523555/222927568-d3d7b3fb-c895-4919-8157-2752d71871bf.png">
