### PR TITLE
Use path when file-name can't be ascertained

### DIFF
--- a/src/fs/erdtree/node.rs
+++ b/src/fs/erdtree/node.rs
@@ -228,7 +228,10 @@ impl From<NodePrecursor> for Node {
             .ok()
             .flatten();
 
-        let file_name = path.file_name().map(|os_str| os_str.to_owned()).unwrap();
+        let file_name = path.file_name().map_or_else(
+            || OsString::from(path.display().to_string()),
+            |os_str| os_str.to_owned(),
+        );
 
         let style = get_ls_colors()
             .style_for_path_with_metadata(path, metadata.as_ref())


### PR DESCRIPTION
Closes https://github.com/solidiquis/erdtree/issues/31

Fix is simple: When file-name can't be ascertained as in the case of `/` we'll fall back on just using the path.