### PR TITLE
Disk usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "ansi_term",
  "clap",
  "crossbeam",
+ "filesize",
  "ignore",
  "indoc",
  "lscolors",
@@ -198,6 +199,15 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "filesize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d741e2415d4e2e5bd1c1d00409d1a8865a57892c2d689b504365655d237d43"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ path = "src/main.rs"
 ansi_term = "0.12.1"
 clap = { version = "4.1.1", features = ["derive"] }
 crossbeam = "0.8.2"
+filesize = "0.2.0"
 ignore = "0.4.2"
 lscolors = { version = "0.13.0", features = ["ansi_term"] }
 once_cell = "1.17.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,7 +97,8 @@ pub enum DiskUsage {
     /// How many bytes does a file contain
     Logical,
 
-    /// How much actual space on disk, taking into account sparse files and compression.
+    /// How much actual space on disk based on blocks allocated, taking into account sparse files
+    /// and compression.
     Physical,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,10 +105,9 @@ pub enum DiskUsage {
 impl Clargs {
     /// Returns reference to the path of the root directory to be traversed.
     pub fn dir(&self) -> &Path {
-        self.dir.as_ref().map_or_else(
-            || Path::new("."),
-            |pb| pb.as_path()
-        )
+        self.dir
+            .as_ref()
+            .map_or_else(|| Path::new("."), |pb| pb.as_path())
     }
 
     /// The sort-order used for printing.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,8 +7,7 @@ use std::{
     convert::From,
     error::Error as StdError,
     fmt::{self, Display, Formatter},
-    fs,
-    io,
+    fs, io,
     path::{Path, PathBuf},
     usize,
 };
@@ -146,8 +145,7 @@ impl TryFrom<&Clargs> for WalkParallel {
     fn try_from(clargs: &Clargs) -> Result<Self, Self::Error> {
         let root = fs::canonicalize(clargs.dir())?;
 
-        fs::metadata(&root)
-            .map_err(|e| Error::DirNotFound(format!("{}: {e}", root.display())))?;
+        fs::metadata(&root).map_err(|e| Error::DirNotFound(format!("{}: {e}", root.display())))?;
 
         Ok(WalkBuilder::new(root)
             .follow_links(clargs.follow_links)

--- a/src/fs/erdtree/disk_usage.rs
+++ b/src/fs/erdtree/disk_usage.rs
@@ -1,0 +1,21 @@
+use crate::cli;
+use std::convert::From;
+
+/// Determines between logical or physical size for display
+#[derive(Debug)]
+pub enum DiskUsage {
+    /// How many bytes does a file contain
+    Logical,
+
+    /// How much actual space on disk, taking into account sparse files and compression.
+    Physical,
+}
+
+impl From<&cli::DiskUsage> for DiskUsage {
+    fn from(du: &cli::DiskUsage) -> Self {
+        match du {
+            cli::DiskUsage::Logical => Self::Logical,
+            cli::DiskUsage::Physical => Self::Physical,
+        }
+    }
+}

--- a/src/fs/erdtree/mod.rs
+++ b/src/fs/erdtree/mod.rs
@@ -1,3 +1,6 @@
+/// Operations that decide how to present info about disk usage.
+pub mod disk_usage;
+
 /// Contains components of the [`Tree`] data structure that derive from [`DirEntry`].
 ///
 /// [`Tree`]: tree::Tree

--- a/src/fs/erdtree/node.rs
+++ b/src/fs/erdtree/node.rs
@@ -1,7 +1,4 @@
-use super::{
-    disk_usage::DiskUsage,
-    get_ls_colors
-};
+use super::{disk_usage::DiskUsage, get_ls_colors};
 use crate::{
     fs::file_size::FileSize,
     icons::{self, icon_from_ext, icon_from_file_name, icon_from_file_type},

--- a/src/fs/erdtree/order.rs
+++ b/src/fs/erdtree/order.rs
@@ -23,7 +23,7 @@ impl Order {
         if self.dir_first {
             return Some(Box::new(|a, b| {
                 Self::dir_comparator(a, b, self.sort.comparator())
-            }))
+            }));
         }
 
         self.sort.comparator()
@@ -37,7 +37,7 @@ impl Order {
         match (a.is_dir(), b.is_dir()) {
             (true, false) => Ordering::Less,
             (false, true) => Ordering::Greater,
-            _ => fallback.map_or_else(|| Ordering::Equal, |sort| sort(a, b))
+            _ => fallback.map_or_else(|| Ordering::Equal, |sort| sort(a, b)),
         }
     }
 }

--- a/src/fs/erdtree/order.rs
+++ b/src/fs/erdtree/order.rs
@@ -7,6 +7,7 @@ use std::{cmp::Ordering, convert::From};
 pub enum SortType {
     Name,
     Size,
+    SizeRev,
     None,
 }
 
@@ -20,12 +21,12 @@ impl Order {
     /// Yields function pointer to the appropriate `Node` comparator.
     pub fn comparator(&self) -> Option<Box<dyn Fn(&Node, &Node) -> Ordering + '_>> {
         if self.dir_first {
-            Some(Box::new(|a, b| {
+            return Some(Box::new(|a, b| {
                 Self::dir_comparator(a, b, self.sort.comparator())
             }))
-        } else {
-            self.sort.comparator()
         }
+
+        self.sort.comparator()
     }
 
     fn dir_comparator(
@@ -36,13 +37,7 @@ impl Order {
         match (a.is_dir(), b.is_dir()) {
             (true, false) => Ordering::Less,
             (false, true) => Ordering::Greater,
-            _ => {
-                if let Some(sort) = fallback {
-                    sort(a, b)
-                } else {
-                    Ordering::Equal
-                }
-            }
+            _ => fallback.map_or_else(|| Ordering::Equal, |sort| sort(a, b))
         }
     }
 }
@@ -53,6 +48,7 @@ impl SortType {
         match self {
             Self::Name => Some(Box::new(Self::name_comparator)),
             Self::Size => Some(Box::new(Self::size_comparator)),
+            Self::SizeRev => Some(Box::new(Self::size_rev_comparator)),
             _ => None,
         }
     }
@@ -62,11 +58,18 @@ impl SortType {
         a.file_name().cmp(b.file_name())
     }
 
-    /// Comparator based on `Node` file sizes
+    /// Comparator that sorts [Node]s by size smallest to largest.
     fn size_comparator(a: &Node, b: &Node) -> Ordering {
         let a_size = a.file_size.unwrap_or(0);
         let b_size = b.file_size.unwrap_or(0);
 
+        a_size.cmp(&b_size)
+    }
+
+    /// Comparator that sorts [Node]s by size largest to smallest.
+    fn size_rev_comparator(a: &Node, b: &Node) -> Ordering {
+        let a_size = a.file_size.unwrap_or(0);
+        let b_size = b.file_size.unwrap_or(0);
         b_size.cmp(&a_size)
     }
 }
@@ -85,6 +88,7 @@ impl From<cli::Order> for SortType {
         match ord {
             cli::Order::Name => SortType::Name,
             cli::Order::Size => SortType::Size,
+            cli::Order::SizeRev => SortType::SizeRev,
             cli::Order::None => SortType::None,
         }
     }

--- a/src/fs/erdtree/tree/mod.rs
+++ b/src/fs/erdtree/tree/mod.rs
@@ -1,8 +1,8 @@
 use super::{
-    disk_usage::DiskUsage,
     super::error::Error,
+    disk_usage::DiskUsage,
     node::{Node, NodePrecursor},
-    order::Order
+    order::Order,
 };
 use crate::cli::Clargs;
 use crossbeam::channel::{self, Sender};
@@ -44,7 +44,7 @@ impl Tree {
         order: Order,
         level: Option<usize>,
         icons: bool,
-        disk_usage: DiskUsage
+        disk_usage: DiskUsage,
     ) -> TreeResult<Self> {
         let root = Self::traverse(walker, &order, icons, &disk_usage)?;
 
@@ -67,7 +67,12 @@ impl Tree {
     /// system calls are expected to occur during parallel traversal; thus post-processing of all
     /// directory entries should be completely CPU-bound. If filesystem I/O or system calls occur
     /// outside of the parallel traversal step please report an issue.
-    fn traverse(walker: WalkParallel, order: &Order, icons: bool, disk_usage: &DiskUsage) -> TreeResult<Node> {
+    fn traverse(
+        walker: WalkParallel,
+        order: &Order,
+        icons: bool,
+        disk_usage: &DiskUsage,
+    ) -> TreeResult<Node> {
         let (tx, rx) = channel::unbounded::<Node>();
 
         // Receives directory entries from the workers used for parallel traversal to construct the

--- a/src/fs/erdtree/tree/mod.rs
+++ b/src/fs/erdtree/tree/mod.rs
@@ -1,9 +1,9 @@
-use crate::cli::Clargs;
 use super::order::Order;
 use super::{
     super::error::Error,
-    node::{Node, NodePrecursor}
+    node::{Node, NodePrecursor},
 };
+use crate::cli::Clargs;
 use crossbeam::channel::{self, Sender};
 use ignore::{WalkParallel, WalkState};
 use std::{
@@ -36,10 +36,20 @@ pub type TreeComponents = (Node, Branches);
 
 impl Tree {
     /// Initializes a [Tree].
-    pub fn new(walker: WalkParallel, order: Order, level: Option<usize>, icons: bool) -> TreeResult<Self> {
+    pub fn new(
+        walker: WalkParallel,
+        order: Order,
+        level: Option<usize>,
+        icons: bool,
+    ) -> TreeResult<Self> {
         let root = Self::traverse(walker, &order, icons)?;
 
-        Ok(Self { level, order, root, icons })
+        Ok(Self {
+            level,
+            order,
+            root,
+            icons,
+        })
     }
 
     /// Returns a reference to the root [Node].
@@ -199,8 +209,10 @@ impl Display for Tree {
                     if let Some(iter_children) = child.children() {
                         let mut new_base = base_prefix.to_owned();
 
-                        let new_theme =
-                            child.is_symlink().then(|| ui::get_link_theme()).unwrap_or(theme);
+                        let new_theme = child
+                            .is_symlink()
+                            .then(|| ui::get_link_theme())
+                            .unwrap_or(theme);
 
                         if last_entry {
                             new_base.push_str(ui::SEP);

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,10 +1,10 @@
-use ansi_term::Color;
 use crate::hash;
+use ansi_term::Color;
 use once_cell::sync::Lazy;
 use std::{
     collections::HashMap,
     ffi::{OsStr, OsString},
-    fs::FileType
+    fs::FileType,
 };
 
 /// Lazily evaluated static hash-map of special file-types and their corresponding styled icons.

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -51,15 +51,15 @@ fn sort_size() {
         indoc!(
             "
             data (1.24 KB)
-            ├─ lipsum (446.00 B)
-            │  └─ lipsum.txt (446.00 B)
-            ├─ dream_cycle (308.00 B)
-            │  └─ polaris.txt (308.00 B)
-            ├─ nemesis.txt (161.00 B)
+            ├─ necronomicon.txt (83.00 B)
+            ├─ nylarlathotep.txt (100.00 B)
             ├─ the_yellow_king (143.00 B)
             │  └─ cassildas_song.md (143.00 B)
-            ├─ nylarlathotep.txt (100.00 B)
-            └─ necronomicon.txt (83.00 B)"
+            ├─ nemesis.txt (161.00 B)
+            ├─ dream_cycle (308.00 B)
+            │  └─ polaris.txt (308.00 B)
+            └─ lipsum (446.00 B)
+               └─ lipsum.txt (446.00 B)"
         ),
         "Failed to sort by descending size"
     )
@@ -72,15 +72,15 @@ fn sort_size_dir_first() {
         indoc!(
             "
             data (1.24 KB)
-            ├─ lipsum (446.00 B)
-            │  └─ lipsum.txt (446.00 B)
-            ├─ dream_cycle (308.00 B)
-            │  └─ polaris.txt (308.00 B)
             ├─ the_yellow_king (143.00 B)
             │  └─ cassildas_song.md (143.00 B)
-            ├─ nemesis.txt (161.00 B)
+            ├─ dream_cycle (308.00 B)
+            │  └─ polaris.txt (308.00 B)
+            ├─ lipsum (446.00 B)
+            │  └─ lipsum.txt (446.00 B)
+            ├─ necronomicon.txt (83.00 B)
             ├─ nylarlathotep.txt (100.00 B)
-            └─ necronomicon.txt (83.00 B)"
+            └─ nemesis.txt (161.00 B)"
         ),
         "Failed to sort by directory and descending size"
     )


### PR DESCRIPTION
### Additions

```
-d, --disk-usage <DISK_USAGE>  Print physical or logical file size [default: logical] [possible values: logical, physical]
-s, --sort <SORT>              Sort-order to display directory content [default: none] [possible values: name, size, size-rev, none]
```

- Adds option to view either logical or physical disk usages with logical being the default:
- Sorting by file size by defaults prints the largest files towards the bottom. People usually are more interested the larger files and it's annoying to have to scroll up for larger file-trees.
- Added ability to sort by file size in reverse