### PR TITLE
support scale for disk usage report

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,10 @@ pub struct Clargs {
     #[arg(short, long, value_name = "NUM")]
     pub level: Option<usize>,
 
+    /// Total number of digits after the decimal to display for disk usage
+    #[arg(short = 'n', long, default_value_t = 2, value_name = "NUM")]
+    pub scale: usize,
+
     /// Sort-order to display directory content
     #[arg(short, long, value_enum, default_value_t = Order::None)]
     sort: Order,

--- a/src/fs/erdtree/node.rs
+++ b/src/fs/erdtree/node.rs
@@ -218,15 +218,17 @@ pub struct NodePrecursor<'a> {
     disk_usage: &'a DiskUsage,
     dir_entry: DirEntry,
     show_icon: bool,
+    scale: usize,
 }
 
 impl<'a> NodePrecursor<'a> {
     /// Yields a [NodePrecursor] which is used for convenient conversion into a [Node].
-    pub fn new(disk_usage: &'a DiskUsage, dir_entry: DirEntry, show_icon: bool) -> Self {
+    pub fn new(disk_usage: &'a DiskUsage, dir_entry: DirEntry, show_icon: bool, scale: usize) -> Self {
         Self {
             disk_usage,
             dir_entry,
             show_icon,
+            scale,
         }
     }
 }
@@ -237,6 +239,7 @@ impl From<NodePrecursor<'_>> for Node {
             disk_usage,
             dir_entry,
             show_icon,
+            scale,
         } = precursor;
 
         let children = None;
@@ -272,8 +275,8 @@ impl From<NodePrecursor<'_>> for Node {
             if ft.is_file() {
                 if let Some(ref md) = metadata {
                     file_size = match disk_usage {
-                        DiskUsage::Logical => Some(FileSize::logical(md)),
-                        DiskUsage::Physical => FileSize::physical(path, md),
+                        DiskUsage::Logical => Some(FileSize::logical(md, scale)),
+                        DiskUsage::Physical => FileSize::physical(path, md, scale),
                     }
                 }
             }

--- a/tests/glob.rs
+++ b/tests/glob.rs
@@ -9,13 +9,13 @@ fn glob() {
         indoc!(
             "
             data (1.07 KiB)
-            ├─ dream_cycle (308.00 B)
-            │  └─ polaris.txt (308.00 B)
-            ├─ lipsum (446.00 B)
-            │  └─ lipsum.txt (446.00 B)
-            ├─ necronomicon.txt (83.00 B)
-            ├─ nemesis.txt (161.00 B)
-            ├─ nylarlathotep.txt (100.00 B)
+            ├─ dream_cycle (308 B)
+            │  └─ polaris.txt (308 B)
+            ├─ lipsum (446 B)
+            │  └─ lipsum.txt (446 B)
+            ├─ necronomicon.txt (83 B)
+            ├─ nemesis.txt (161 B)
+            ├─ nylarlathotep.txt (100 B)
             └─ the_yellow_king"
         )
     )
@@ -27,11 +27,11 @@ fn glob_negative() {
         utils::run_cmd(&["--sort", "name", "--glob", "!*.txt", "tests/data"]),
         indoc!(
             "
-            data (143.00 B)
+            data (143 B)
             ├─ dream_cycle 
             ├─ lipsum 
-            └─ the_yellow_king (143.00 B)
-               └─ cassildas_song.md (143.00 B)"
+            └─ the_yellow_king (143 B)
+               └─ cassildas_song.md (143 B)"
         )
     )
 }
@@ -50,13 +50,13 @@ fn glob_case_insensitive() {
         indoc!(
             "
             data (1.07 KiB)
-            ├─ dream_cycle (308.00 B)
-            │  └─ polaris.txt (308.00 B)
-            ├─ lipsum (446.00 B)
-            │  └─ lipsum.txt (446.00 B)
-            ├─ necronomicon.txt (83.00 B)
-            ├─ nemesis.txt (161.00 B)
-            ├─ nylarlathotep.txt (100.00 B)
+            ├─ dream_cycle (308 B)
+            │  └─ polaris.txt (308 B)
+            ├─ lipsum (446 B)
+            │  └─ lipsum.txt (446 B)
+            ├─ necronomicon.txt (83 B)
+            ├─ nemesis.txt (161 B)
+            ├─ nylarlathotep.txt (100 B)
             └─ the_yellow_king"
         )
     )
@@ -69,13 +69,13 @@ fn iglob() {
         indoc!(
             "
             data (1.07 KiB)
-            ├─ dream_cycle (308.00 B)
-            │  └─ polaris.txt (308.00 B)
-            ├─ lipsum (446.00 B)
-            │  └─ lipsum.txt (446.00 B)
-            ├─ necronomicon.txt (83.00 B)
-            ├─ nemesis.txt (161.00 B)
-            ├─ nylarlathotep.txt (100.00 B)
+            ├─ dream_cycle (308 B)
+            │  └─ polaris.txt (308 B)
+            ├─ lipsum (446 B)
+            │  └─ lipsum.txt (446 B)
+            ├─ necronomicon.txt (83 B)
+            ├─ nemesis.txt (161 B)
+            ├─ nylarlathotep.txt (100 B)
             └─ the_yellow_king"
        )
     )

--- a/tests/level.rs
+++ b/tests/level.rs
@@ -9,12 +9,12 @@ fn level() {
         indoc!(
             "
             data (1.21 KiB)
-            ├─ dream_cycle (308.00 B)
-            ├─ lipsum (446.00 B)
-            ├─ necronomicon.txt (83.00 B)
-            ├─ nemesis.txt (161.00 B)
-            ├─ nylarlathotep.txt (100.00 B)
-            └─ the_yellow_king (143.00 B)"
+            ├─ dream_cycle (308 B)
+            ├─ lipsum (446 B)
+            ├─ necronomicon.txt (83 B)
+            ├─ nemesis.txt (161 B)
+            ├─ nylarlathotep.txt (100 B)
+            └─ the_yellow_king (143 B)"
         ),
         "Failed to print at max level of 1."
     )

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -9,15 +9,15 @@ fn sort_name() {
         indoc!(
             "
             data (1.21 KiB)
-            ├─ dream_cycle (308.00 B)
-            │  └─ polaris.txt (308.00 B)
-            ├─ lipsum (446.00 B)
-            │  └─ lipsum.txt (446.00 B)
-            ├─ necronomicon.txt (83.00 B)
-            ├─ nemesis.txt (161.00 B)
-            ├─ nylarlathotep.txt (100.00 B)
-            └─ the_yellow_king (143.00 B)
-               └─ cassildas_song.md (143.00 B)"
+            ├─ dream_cycle (308 B)
+            │  └─ polaris.txt (308 B)
+            ├─ lipsum (446 B)
+            │  └─ lipsum.txt (446 B)
+            ├─ necronomicon.txt (83 B)
+            ├─ nemesis.txt (161 B)
+            ├─ nylarlathotep.txt (100 B)
+            └─ the_yellow_king (143 B)
+               └─ cassildas_song.md (143 B)"
         ),
         "Failed to sort alphabetically by file name"
     )
@@ -30,15 +30,15 @@ fn sort_name_dir_first() {
         indoc!(
             "
             data (1.21 KiB)
-            ├─ dream_cycle (308.00 B)
-            │  └─ polaris.txt (308.00 B)
-            ├─ lipsum (446.00 B)
-            │  └─ lipsum.txt (446.00 B)
-            ├─ the_yellow_king (143.00 B)
-            │  └─ cassildas_song.md (143.00 B)
-            ├─ necronomicon.txt (83.00 B)
-            ├─ nemesis.txt (161.00 B)
-            └─ nylarlathotep.txt (100.00 B)"
+            ├─ dream_cycle (308 B)
+            │  └─ polaris.txt (308 B)
+            ├─ lipsum (446 B)
+            │  └─ lipsum.txt (446 B)
+            ├─ the_yellow_king (143 B)
+            │  └─ cassildas_song.md (143 B)
+            ├─ necronomicon.txt (83 B)
+            ├─ nemesis.txt (161 B)
+            └─ nylarlathotep.txt (100 B)"
         ),
         "Failed to sort by directory and alphabetically by file name"
     )
@@ -51,15 +51,15 @@ fn sort_size() {
         indoc!(
             "
             data (1.21 KiB)
-            ├─ necronomicon.txt (83.00 B)
-            ├─ nylarlathotep.txt (100.00 B)
-            ├─ the_yellow_king (143.00 B)
-            │  └─ cassildas_song.md (143.00 B)
-            ├─ nemesis.txt (161.00 B)
-            ├─ dream_cycle (308.00 B)
-            │  └─ polaris.txt (308.00 B)
-            └─ lipsum (446.00 B)
-               └─ lipsum.txt (446.00 B)"
+            ├─ necronomicon.txt (83 B)
+            ├─ nylarlathotep.txt (100 B)
+            ├─ the_yellow_king (143 B)
+            │  └─ cassildas_song.md (143 B)
+            ├─ nemesis.txt (161 B)
+            ├─ dream_cycle (308 B)
+            │  └─ polaris.txt (308 B)
+            └─ lipsum (446 B)
+               └─ lipsum.txt (446 B)"
         ),
         "Failed to sort by descending size"
     )
@@ -72,15 +72,15 @@ fn sort_size_dir_first() {
         indoc!(
             "
             data (1.21 KiB)
-            ├─ the_yellow_king (143.00 B)
-            │  └─ cassildas_song.md (143.00 B)
-            ├─ dream_cycle (308.00 B)
-            │  └─ polaris.txt (308.00 B)
-            ├─ lipsum (446.00 B)
-            │  └─ lipsum.txt (446.00 B)
-            ├─ necronomicon.txt (83.00 B)
-            ├─ nylarlathotep.txt (100.00 B)
-            └─ nemesis.txt (161.00 B)"
+            ├─ the_yellow_king (143 B)
+            │  └─ cassildas_song.md (143 B)
+            ├─ dream_cycle (308 B)
+            │  └─ polaris.txt (308 B)
+            ├─ lipsum (446 B)
+            │  └─ lipsum.txt (446 B)
+            ├─ necronomicon.txt (83 B)
+            ├─ nylarlathotep.txt (100 B)
+            └─ nemesis.txt (161 B)"
         ),
         "Failed to sort by directory and descending size"
     )

--- a/tests/symlink.rs
+++ b/tests/symlink.rs
@@ -23,8 +23,8 @@ mod test {
             super::utils::run_cmd(&["--sort", "name", "--follow-links", &link_canonical]),
             indoc!(
                 "
-                the_yellow_king (143.00 B)
-                └─ cassildas_song.md (143.00 B)"
+                the_yellow_king (143 B)
+                └─ cassildas_song.md (143 B)"
             ),
             "Failed to print symlink"
         );


### PR DESCRIPTION
Added an option to adjust the scale (numbers after the decimal point) used for disk usage reports:

```
  -n, --scale <NUM>              Total number of digits after the decimal to display for disk usage [default: 2]
```

<img width="801" alt="Screen Shot 2023-03-05 at 10 27 48 PM" src="https://user-images.githubusercontent.com/45523555/223034973-e8c3d64f-496d-43c6-a4b7-b1b4e80b0cab.png">
