### PR TITLE
don't hash inode if number of links is 1

### DIFF
--- a/src/fs/erdtree/tree/mod.rs
+++ b/src/fs/erdtree/tree/mod.rs
@@ -99,11 +99,13 @@ impl Tree {
                         root = Some(node);
                         continue;
                     }
-                } else {
-                    // If a hard-link is already accounted for skip the subsequent one.
-                    if let Some(inode) = node.inode() {
+                }
+
+                if let Some(inode) = node.inode() {
+                    if inode.nlink > 1 {
+                        // If a hard-link is already accounted for skip the subsequent one.
                         if !inodes.insert(inode.properties()) {
-                            continue
+                            continue;
                         }
                     }
                 }

--- a/src/fs/inode.rs
+++ b/src/fs/inode.rs
@@ -8,9 +8,9 @@ use std::{
 /// Represents a file's underlying inode.
 #[derive(Debug)]
 pub struct Inode {
-    ino: u64,
-    dev: u64,
-    nlink: u64
+    pub ino: u64,
+    pub dev: u64,
+    pub nlink: u64
 }
 
 impl Inode {
@@ -19,9 +19,9 @@ impl Inode {
         Self { ino, dev, nlink }
     }
 
-    /// Returns a tuple of all the fields of the [Inode].
-    pub fn properties(&self) -> (u64, u64, u64) {
-        (self.ino, self.dev, self.nlink)
+    /// Returns a tuple fields of the [Inode] that mark is unique.
+    pub fn properties(&self) -> (u64, u64) {
+        (self.ino, self.dev)
     }
 }
 


### PR DESCRIPTION
Minor optimization: Don't hash inode properties if `nlinks` is 1 i.e. there is only 1 hardlink.