### PR TITLE
Option to toggle SI and Binary prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Options:
   -i, --ignore-git-ignore        Ignore .gitignore; disabled by default
   -l, --level <NUM>              Maximum depth to display
   -n, --scale <NUM>              Total number of digits after the decimal to display for disk usage [default: 2]
+  -p, --prefix <PREFIX>          Display disk usage as binary or SI units [default: bin] [possible values: bin, si]
   -s, --sort <SORT>              Sort-order to display directory content [possible values: name, size, size-rev]
       --dirs-first               Always sorts directories above files
   -S, --follow-links             Traverse symlink directories and consider their disk usage; disabled by default
@@ -120,10 +121,9 @@ $ cat $HOME/.erdtreerc
 -s size
 ```
 
-
 ### Binary prefix or SI Prefix
 
-Disk usage is reported using binary prefixes, thus you can expect `1 kebibyte` to equal `1024 bytes` (i.e `1 KiB = 1024 B`).
+Disk usage is reported using binary prefixes by default (e.g. `1 KiB = 1024 B`) as opposed to SI prefixes (`1 KB = 1000 B`). To toggle between the two use the `-p, --prefix` option.
 
 ### Logical or physical disk usage
 

--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -1,4 +1,7 @@
-use super::{disk_usage::DiskUsage, order::SortType};
+use super::{
+    disk_usage::{DiskUsage, PrefixKind},
+    order::SortType,
+};
 use clap::{CommandFactory, Error as ClapError, FromArgMatches, Parser};
 use ignore::overrides::{Override, OverrideBuilder};
 use std::{
@@ -65,6 +68,10 @@ pub struct Context {
     /// Total number of digits after the decimal to display for disk usage
     #[arg(short = 'n', long, default_value_t = 2, value_name = "NUM")]
     pub scale: usize,
+
+    /// Total number of digits after the decimal to display for disk usage
+    #[arg(short, long, value_enum, default_value_t = PrefixKind::Bin)]
+    pub prefix: PrefixKind,
 
     /// Sort-order to display directory content
     #[arg(short, long, value_enum)]

--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -69,7 +69,7 @@ pub struct Context {
     #[arg(short = 'n', long, default_value_t = 2, value_name = "NUM")]
     pub scale: usize,
 
-    /// Total number of digits after the decimal to display for disk usage
+    /// Display disk usage as binary or SI units
     #[arg(short, long, value_enum, default_value_t = PrefixKind::Bin)]
     pub prefix: PrefixKind,
 

--- a/src/render/disk_usage.rs
+++ b/src/render/disk_usage.rs
@@ -18,13 +18,34 @@ pub enum DiskUsage {
     Physical,
 }
 
-/// Binary prefixes
+/// Determines whether to use SI prefixes or binary prefixes.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum PrefixKind {
+    /// Displays disk usage using binary prefixes.
+    Bin,
+
+    /// Displays disk usage using SI prefixes.
+    Si,
+}
+
+/// Binary prefixes.
 #[derive(Debug)]
-pub enum Prefix {
+pub enum BinPrefix {
     Base,
     Kibi,
     Mebi,
     Gibi,
+    Tebi,
+}
+
+/// Binary prefixes
+#[derive(Debug)]
+pub enum SiPrefix {
+    Base,
+    Kilo,
+    Mega,
+    Giga,
+    Tera,
 }
 
 /// Represents either logical or physical size and handles presentation.
@@ -33,30 +54,37 @@ pub struct FileSize {
     pub bytes: u64,
     #[allow(dead_code)]
     disk_usage: DiskUsage,
+    prefix_kind: PrefixKind,
     scale: usize,
 }
 
 impl FileSize {
     /// Initializes a [FileSize].
-    pub fn new(bytes: u64, disk_usage: DiskUsage, scale: usize) -> Self {
+    pub fn new(bytes: u64, disk_usage: DiskUsage, prefix_kind: PrefixKind, scale: usize) -> Self {
         Self {
             bytes,
             disk_usage,
+            prefix_kind,
             scale,
         }
     }
 
     /// Computes the logical size of a file given its [Metadata].
-    pub fn logical(md: &Metadata, scale: usize) -> Self {
+    pub fn logical(md: &Metadata, prefix_kind: PrefixKind, scale: usize) -> Self {
         let bytes = md.len();
-        Self::new(bytes, DiskUsage::Logical, scale)
+        Self::new(bytes, DiskUsage::Logical, prefix_kind, scale)
     }
 
     /// Computes the physical size of a file given its [Path] and [Metadata].
-    pub fn physical(path: &Path, md: &Metadata, scale: usize) -> Option<Self> {
+    pub fn physical(
+        path: &Path,
+        md: &Metadata,
+        prefix_kind: PrefixKind,
+        scale: usize,
+    ) -> Option<Self> {
         path.size_on_disk_fast(md)
             .ok()
-            .map(|bytes| Self::new(bytes, DiskUsage::Physical, scale))
+            .map(|bytes| Self::new(bytes, DiskUsage::Physical, prefix_kind, scale))
     }
 }
 
@@ -69,44 +97,105 @@ impl AddAssign<&Self> for FileSize {
 impl Display for FileSize {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let fbytes = self.bytes as f64;
-        let log = fbytes.log(2.0);
 
-        let output = if log < 10.0 {
-            Color::Cyan.paint(format!("{} {}", self.bytes, Prefix::Base))
-        } else if (10.0..20.0).contains(&log) {
-            Color::Yellow.paint(format!(
-                "{:.scale$} {}",
-                fbytes / 1024.0_f64,
-                Prefix::Kibi,
-                scale = self.scale
-            ))
-        } else if (20.0..30.0).contains(&log) {
-            Color::Green.paint(format!(
-                "{:.scale$} {}",
-                fbytes / 1024.0_f64.powi(2),
-                Prefix::Mebi,
-                scale = self.scale
-            ))
-        } else {
-            Color::Red.paint(format!(
-                "{:.scale$} {}",
-                fbytes / 1024.0_f64.powi(3),
-                Prefix::Gibi,
-                scale = self.scale
-            ))
+        let output = match self.prefix_kind {
+            PrefixKind::Bin => {
+                let log = fbytes.log(2.0);
+
+                if log < 10.0 {
+                    Color::Cyan.paint(format!("{} {}", self.bytes, BinPrefix::Base))
+                } else if (10.0..20.0).contains(&log) {
+                    Color::Yellow.paint(format!(
+                        "{:.scale$} {}",
+                        fbytes / 1024.0_f64,
+                        BinPrefix::Kibi,
+                        scale = self.scale
+                    ))
+                } else if (20.0..30.0).contains(&log) {
+                    Color::Green.paint(format!(
+                        "{:.scale$} {}",
+                        fbytes / 1024.0_f64.powi(2),
+                        BinPrefix::Mebi,
+                        scale = self.scale
+                    ))
+                } else if (30.0..40.0).contains(&log) {
+                    Color::Red.paint(format!(
+                        "{:.scale$} {}",
+                        fbytes / 1024.0_f64.powi(3),
+                        BinPrefix::Gibi,
+                        scale = self.scale
+                    ))
+                } else {
+                    Color::Blue.paint(format!(
+                        "{:.scale$} {}",
+                        fbytes / 1024.0_f64.powi(4),
+                        BinPrefix::Tebi,
+                        scale = self.scale
+                    ))
+                }
+            }
+
+            PrefixKind::Si => {
+                let log = fbytes.log(10.0);
+
+                if log < 3.0 {
+                    Color::Cyan.paint(format!("{} {}", fbytes, SiPrefix::Base))
+                } else if (3.0..6.0).contains(&log) {
+                    Color::Yellow.paint(format!(
+                        "{:.scale$} {}",
+                        fbytes / 10.0_f64.powi(3),
+                        SiPrefix::Kilo,
+                        scale = self.scale
+                    ))
+                } else if (6.0..9.0).contains(&log) {
+                    Color::Green.paint(format!(
+                        "{:.scale$} {}",
+                        fbytes / 10.0_f64.powi(6),
+                        SiPrefix::Mega,
+                        scale = self.scale
+                    ))
+                } else if (9.0..12.0).contains(&log) {
+                    Color::Green.paint(format!(
+                        "{:.scale$} {}",
+                        fbytes / 10.0_f64.powi(9),
+                        SiPrefix::Giga,
+                        scale = self.scale
+                    ))
+                } else {
+                    Color::Red.paint(format!(
+                        "{:.scale$} {}",
+                        fbytes / 10.0_f64.powi(12),
+                        SiPrefix::Tera,
+                        scale = self.scale
+                    ))
+                }
+            }
         };
 
         write!(f, "{output}")
     }
 }
 
-impl Display for Prefix {
+impl Display for BinPrefix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Prefix::Base => write!(f, "B"),
-            Prefix::Kibi => write!(f, "KiB"),
-            Prefix::Mebi => write!(f, "MiB"),
-            Prefix::Gibi => write!(f, "GiB"),
+            Self::Base => write!(f, "B"),
+            Self::Kibi => write!(f, "KiB"),
+            Self::Mebi => write!(f, "MiB"),
+            Self::Gibi => write!(f, "GiB"),
+            Self::Tebi => write!(f, "TiB"),
+        }
+    }
+}
+
+impl Display for SiPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Base => write!(f, "B"),
+            Self::Kilo => write!(f, "KB"),
+            Self::Mega => write!(f, "MB"),
+            Self::Giga => write!(f, "GB"),
+            Self::Tera => write!(f, "TB"),
         }
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -6,12 +6,6 @@ pub mod context;
 /// Operations that decide how to present info about disk usage.
 pub mod disk_usage;
 
-/// Contains components of the [`Tree`] data structure that derive from [`DirEntry`].
-///
-/// [`Tree`]: tree::Tree
-/// [`DirEntry`]: ignore::DirEntry
-pub mod node;
-
 /// Ordering operations for printing.
 pub mod order;
 

--- a/src/render/node.rs
+++ b/src/render/node.rs
@@ -2,7 +2,10 @@ use super::get_ls_colors;
 use crate::{
     fs::inode::Inode,
     icons::{self, icon_from_ext, icon_from_file_name, icon_from_file_type},
-    render::disk_usage::{DiskUsage, FileSize},
+    render::{
+        context::Context,
+        disk_usage::{DiskUsage, FileSize},
+    },
 };
 use ansi_term::Color;
 use ansi_term::Style;
@@ -210,43 +213,20 @@ impl Node {
     }
 }
 
-/// Used to be converted directly into a [Node].
-pub struct NodePrecursor<'a> {
-    disk_usage: &'a DiskUsage,
-    dir_entry: DirEntry,
-    show_icon: bool,
-    scale: usize,
-    suppress_size: bool,
-}
-
-impl<'a> NodePrecursor<'a> {
-    /// Yields a [NodePrecursor] which is used for convenient conversion into a [Node].
-    pub fn new(
-        disk_usage: &'a DiskUsage,
-        dir_entry: DirEntry,
-        show_icon: bool,
-        scale: usize,
-        suppress_size: bool,
-    ) -> Self {
-        Self {
+impl From<(&DirEntry, &Context)> for Node {
+    fn from(data: (&DirEntry, &Context)) -> Self {
+        let (dir_entry, ctx) = data;
+        let Context {
             disk_usage,
-            dir_entry,
-            show_icon,
+            icons,
             scale,
             suppress_size,
-        }
-    }
-}
+            ..
+        } = ctx;
 
-impl From<NodePrecursor<'_>> for Node {
-    fn from(precursor: NodePrecursor) -> Self {
-        let NodePrecursor {
-            disk_usage,
-            dir_entry,
-            show_icon,
-            scale,
-            suppress_size,
-        } = precursor;
+        let scale = scale.clone();
+
+        let icons = icons.clone();
 
         let children = None;
 
@@ -300,7 +280,7 @@ impl From<NodePrecursor<'_>> for Node {
             file_type,
             inode,
             path.into(),
-            show_icon,
+            icons,
             style,
             symlink_target,
         )

--- a/src/render/order.rs
+++ b/src/render/order.rs
@@ -1,4 +1,4 @@
-use super::node::Node;
+use super::tree::node::Node;
 use clap::ValueEnum;
 use std::{cmp::Ordering, convert::From};
 

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -1,7 +1,4 @@
-use super::{
-    node::{Node, NodePrecursor},
-    order::Order,
-};
+use super::{node::Node, order::Order};
 use crate::render::{context::Context, disk_usage::FileSize};
 use crossbeam::channel::{self, Sender};
 use error::Error;
@@ -117,16 +114,7 @@ impl Tree {
                 let tx = Sender::clone(&tx);
 
                 entry_res
-                    .map(|entry| {
-                        NodePrecursor::new(
-                            &ctx.disk_usage,
-                            entry,
-                            ctx.icons,
-                            ctx.scale,
-                            ctx.suppress_size,
-                        )
-                    })
-                    .map(Node::from)
+                    .map(|entry| Node::from((&entry, ctx)))
                     .map(|node| tx.send(node).unwrap())
                     .map(|_| WalkState::Continue)
                     .unwrap_or(WalkState::Skip)

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -1,8 +1,9 @@
-use super::{node::Node, order::Order};
+use super::order::Order;
 use crate::render::{context::Context, disk_usage::FileSize};
 use crossbeam::channel::{self, Sender};
 use error::Error;
 use ignore::{WalkBuilder, WalkParallel, WalkState};
+use node::Node;
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,
@@ -15,6 +16,12 @@ use std::{
 
 /// Errors related to traversal, [Tree] construction, and the like.
 pub mod error;
+
+/// Contains components of the [`Tree`] data structure that derive from [`DirEntry`].
+///
+/// [`Tree`]: tree::Tree
+/// [`DirEntry`]: ignore::DirEntry
+pub mod node;
 
 /// [ui::LS_COLORS] initialization and ui theme for [Tree].
 pub mod ui;
@@ -141,7 +148,7 @@ impl Tree {
             })
             .unwrap();
 
-        let mut dir_size = FileSize::new(0, ctx.disk_usage, ctx.scale);
+        let mut dir_size = FileSize::new(0, ctx.disk_usage, ctx.prefix, ctx.scale);
 
         current_node.children_mut().map(|nodes| {
             nodes.iter_mut().for_each(|node| {

--- a/src/render/tree/node.rs
+++ b/src/render/tree/node.rs
@@ -1,4 +1,4 @@
-use super::get_ls_colors;
+use super::super::get_ls_colors;
 use crate::{
     fs::inode::Inode,
     icons::{self, icon_from_ext, icon_from_file_name, icon_from_file_type},
@@ -221,11 +221,12 @@ impl From<(&DirEntry, &Context)> for Node {
             icons,
             scale,
             suppress_size,
+            prefix,
             ..
         } = ctx;
 
         let scale = scale.clone();
-
+        let prefix = prefix.clone();
         let icons = icons.clone();
 
         let children = None;
@@ -262,8 +263,8 @@ impl From<(&DirEntry, &Context)> for Node {
                 if ft.is_file() {
                     if let Some(ref md) = metadata {
                         file_size = match disk_usage {
-                            DiskUsage::Logical => Some(FileSize::logical(md, scale)),
-                            DiskUsage::Physical => FileSize::physical(path, md, scale),
+                            DiskUsage::Logical => Some(FileSize::logical(md, prefix, scale)),
+                            DiskUsage::Physical => FileSize::physical(path, md, prefix, scale),
                         }
                     }
                 }


### PR DESCRIPTION
### Additions

Added an option to toggle between binary and SI prefixes when reporting disk usage.

```
-p, --prefix <PREFIX>          Display disk usage as binary or SI units [default: bin] [possible values: bin, si]
```