### PR TITLE
fix --ignore-git

### DIFF
--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -165,7 +165,7 @@ impl Context {
         let mut builder = OverrideBuilder::new(self.dir());
 
         if self.ignore_git {
-            builder.add("!.git/**/*")?;
+            builder.add("!.git")?;
         }
 
         if self.glob.is_empty() && self.iglob.is_empty() {

--- a/src/render/disk_usage.rs
+++ b/src/render/disk_usage.rs
@@ -38,7 +38,7 @@ pub enum BinPrefix {
     Tebi,
 }
 
-/// Binary prefixes
+/// SI prefixes.
 #[derive(Debug)]
 pub enum SiPrefix {
     Base,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,4 +1,4 @@
-/// CLI rules and definitions and context wherein [Tree] will operate.
+/// CLI rules and definitions and context wherein [`Tree`] will operate.
 ///
 /// [`Tree`]: tree::Tree
 pub mod context;

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -184,6 +184,8 @@ impl TryFrom<&Context> for WalkParallel {
 
         fs::metadata(&root).map_err(|e| Error::DirNotFound(format!("{}: {e}", root.display())))?;
 
+        println!("{:?}", clargs.overrides()?);
+
         Ok(WalkBuilder::new(root)
             .follow_links(clargs.follow_links)
             .git_ignore(!clargs.ignore_git_ignore)

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -184,8 +184,6 @@ impl TryFrom<&Context> for WalkParallel {
 
         fs::metadata(&root).map_err(|e| Error::DirNotFound(format!("{}: {e}", root.display())))?;
 
-        println!("{:?}", clargs.overrides()?);
-
         Ok(WalkBuilder::new(root)
             .follow_links(clargs.follow_links)
             .git_ignore(!clargs.ignore_git_ignore)

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -18,7 +18,7 @@ pub mod error;
 
 /// Contains components of the [`Tree`] data structure that derive from [`DirEntry`].
 ///
-/// [`Tree`]: tree::Tree
+/// [`Tree`]: Tree
 /// [`DirEntry`]: ignore::DirEntry
 pub mod node;
 

--- a/src/render/tree/node.rs
+++ b/src/render/tree/node.rs
@@ -26,8 +26,8 @@ use std::{
 /// relevant system calls are expected to complete after initialization. A `Node` when `Display`ed
 /// uses ANSI colors determined by the file-type and [`LS_COLORS`].
 ///
-/// [`Tree`]: super::tree::Tree
-/// [`LS_COLORS`]: super::tree::ui::LS_COLORS
+/// [`Tree`]: super::Tree
+/// [`LS_COLORS`]: super::ui::LS_COLORS
 #[derive(Debug)]
 pub struct Node {
     pub depth: usize,
@@ -191,7 +191,7 @@ impl Node {
     /// Gets stylized icon for node if enabled. Icons without extensions are styled based on the
     /// [`LS_COLORS`] foreground configuration of the associated file name.
     ///
-    /// [`LS_COLORS`]: super::tree::ui::LS_COLORS
+    /// [`LS_COLORS`]: super::ui::LS_COLORS
     fn get_icon(&self) -> Option<String> {
         if !self.show_icon {
             return None;
@@ -220,7 +220,7 @@ impl Node {
 
     /// Stylizes input, `entity` based on [`LS_COLORS`]
     ///
-    /// [`LS_COLORS`]: super::tree::ui::LS_COLORS
+    /// [`LS_COLORS`]: super::ui::LS_COLORS
     fn stylize(&self, entity: &str) -> String {
         self.style().foreground.map_or_else(
             || entity.to_string(),


### PR DESCRIPTION
Closes https://github.com/solidiquis/erdtree/issues/45

Fixed bug where `--ignore-git` wasn't ignoring `.git` when `-H` was used.