### PR TITLE
Add dir precedence

### DIFF
--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     disk_usage::{DiskUsage, PrefixKind},
-    order::SortType,
+    order::{DirectoryOrdering, SortType},
 };
 use clap::{ArgMatches, CommandFactory, Error as ClapError, FromArgMatches, Parser};
 use ignore::overrides::{Override, OverrideBuilder};
@@ -81,9 +81,9 @@ pub struct Context {
     #[arg(short, long, value_enum)]
     sort: Option<SortType>,
 
-    /// Always sorts directories above files
-    #[arg(long)]
-    dirs_first: bool,
+    /// Orders directories within branch arms
+    #[arg(short = 'D', long, value_name = "ORDER")]
+    dir_order: Option<DirectoryOrdering>,
 
     /// Traverse symlink directories and consider their disk usage; disabled by default
     #[arg(short = 'S', long)]
@@ -151,9 +151,9 @@ impl Context {
         self.sort
     }
 
-    /// Getter for `dirs_first` field.
-    pub fn dirs_first(&self) -> bool {
-        self.dirs_first
+    /// Getter for `dir_order` field.
+    pub fn dir_ordering(&self) -> Option<DirectoryOrdering> {
+        self.dir_order
     }
 
     /// The max depth to print. Note that all directories are fully traversed to compute file

--- a/src/render/order.rs
+++ b/src/render/order.rs
@@ -13,6 +13,9 @@ pub enum SortType {
 
     /// Sort entries by size largest to smallest, bottom to top
     SizeRev,
+
+    /// Do not sort entries
+    None,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -56,6 +59,7 @@ impl SortType {
             Self::Name => Some(Box::new(Self::name_comparator)),
             Self::Size => Some(Box::new(Self::size_comparator)),
             Self::SizeRev => Some(Box::new(Self::size_rev_comparator)),
+            Self::None => None,
         }
     }
 

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -17,6 +17,8 @@ use std::{
     thread,
 };
 
+use super::order::DirectoryOrdering;
+
 /// Errors related to traversal, [Tree] construction, and the like.
 pub mod error;
 
@@ -173,14 +175,10 @@ impl Tree {
             current_node.set_file_size(dir_size)
         }
 
-        if let Some(ordr) = ctx.sort().map(|s| Order::from((s, ctx.dirs_first()))) {
-            ordr.comparator()
-                .map(|func| current_node.sort_children(func));
-        } else if ctx.dirs_first() {
-            Order::from((SortType::None, true))
-                .comparator()
-                .map(|func| current_node.sort_children(func));
-        }
+        let apply_comparator = |comparator| current_node.sort_children(comparator);
+        Order::from((ctx.sort(), ctx.dir_ordering()))
+            .comparators()
+            .for_each(apply_comparator);
     }
 }
 

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -1,4 +1,8 @@
-use crate::render::{context::Context, disk_usage::FileSize, order::Order};
+use crate::render::{
+    context::Context,
+    disk_usage::FileSize,
+    order::{Order, SortType},
+};
 use crossbeam::channel::{self, Sender};
 use error::Error;
 use ignore::{WalkBuilder, WalkParallel, WalkState};
@@ -171,6 +175,10 @@ impl Tree {
 
         if let Some(ordr) = ctx.sort().map(|s| Order::from((s, ctx.dirs_first()))) {
             ordr.comparator()
+                .map(|func| current_node.sort_children(func));
+        } else if ctx.dirs_first() {
+            Order::from((SortType::None, true))
+                .comparator()
                 .map(|func| current_node.sort_children(func));
         }
     }

--- a/src/render/tree/node.rs
+++ b/src/render/tree/node.rs
@@ -86,7 +86,7 @@ impl Node {
     }
 
     /// Sorts `children` given comparator.
-    pub fn sort_children(&mut self, comparator: Box<NodeComparator<'_>>) {
+    pub fn sort_children(&mut self, comparator: Box<NodeComparator>) {
         self.children.sort_by(comparator)
     }
 


### PR DESCRIPTION
This replaces dirs-first with a dir-order option, for ordering directory nodes in branch arms before or after other inodes.  It makes some simplifications to how comparators are generated and applied to sort passes on inodes.

Sorry for jumbling this up with another pr.  Let me know if you'd like me to make any updates.