### PR TITLE
additional locations for config file

### DIFF
--- a/src/render/context/config.rs
+++ b/src/render/context/config.rs
@@ -3,33 +3,30 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub const CONFIG_ENV_VAR: &str = "ERDTREE_CONFIG_PATH";
-pub const CONFIG_NAME: &str = ".erdtreerc";
+pub const ERDTREE_CONFIG_NAME: &str = ".erdtreerc";
+pub const ERDTREE_CONFIG_PATH: &str = "ERDTREE_CONFIG_PATH";
+pub const ERDTREE_DIR: &str = "erdtree";
+pub const CONFIG_DIR: &str = ".config";
+pub const HOME: &str = "HOME";
+pub const XDG_CONFIG_HOME: &str = "XDG_CONFIG_HOME";
 
-/// Reads the config file into a `String` if there is one. When `None` is provided as an argument
-/// `ERDTREE_CONFIG_PATH` is used to locate the path of the configuration file; if that doesn't
-/// yield the config file then `$HOME/.erdtreerc` is checked.
+/// Reads the config file into a `String` if there is one. When `None` is provided then the config
+/// is looked for in the following locations in order:
+///
+/// - `$ERDTREE_CONFIG_NAME`
+/// - `$XDG_CONFIG_HOME/erdtree/.erdtreerc`
+/// - `$XDG_CONFIG_HOME/.erdtreerc`
+/// - `$HOME/.config/erdtree/.erdtreerc`
+/// - `$HOME/.erdtreerc`
 pub fn read_config_to_string<T: AsRef<Path>>(path: Option<T>) -> Option<String> {
     if let Some(p) = path {
-        return fs::read_to_string(p)
-            .map(|config| format!("--\n{config}"))
-            .ok();
+        return fs::read_to_string(p).ok().map(prepend_arg_prefix);
     }
 
-    env::var_os(CONFIG_ENV_VAR)
-        .map(PathBuf::from)
-        .map(fs::read_to_string)
-        .map(Result::ok)
-        .flatten()
-        .or_else(|| {
-            env::var_os("HOME")
-                .map(PathBuf::from)
-                .map(|p| p.join(CONFIG_NAME))
-                .map(fs::read_to_string)
-                .map(Result::ok)
-                .flatten()
-        })
-        .map(|config| format!("--\n{config}"))
+    config_from_config_path()
+        .or_else(config_from_xdg_path)
+        .or_else(config_from_home)
+        .map(prepend_arg_prefix)
 }
 
 /// Parses the config `str`, removing comments and preparing it as a format understood by
@@ -49,4 +46,52 @@ pub fn parse_config<'a>(config: &'a str) -> Vec<&'a str> {
         .map(str::split_ascii_whitespace)
         .flatten()
         .collect::<Vec<&'a str>>()
+}
+
+/// Try to read in config from `ERDTREE_CONFIG_PATH`.
+fn config_from_config_path() -> Option<String> {
+    env::var_os(ERDTREE_CONFIG_PATH)
+        .map(PathBuf::from)
+        .map(fs::read_to_string)
+        .map(Result::ok)
+        .flatten()
+}
+
+/// Try to read in config from either one of the following locations:
+/// - `$HOME/.config/erdtree/.erdtreerc`
+/// - `$HOME/.erdtreerc`
+fn config_from_home() -> Option<String> {
+    let home = env::var_os(HOME).map(PathBuf::from)?;
+
+    let config_path = home
+        .join(CONFIG_DIR)
+        .join(ERDTREE_DIR)
+        .join(ERDTREE_CONFIG_NAME);
+
+    fs::read_to_string(config_path).ok().or_else(|| {
+        let config_path = home.join(ERDTREE_CONFIG_NAME);
+        fs::read_to_string(config_path).ok()
+    })
+}
+
+/// Try to read in config from either one of the following locations:
+/// - `$XDG_CONFIG_HOME/erdtree/.erdtreerc`
+/// - `$XDG_CONFIG_HOME/.erdtreerc`
+fn config_from_xdg_path() -> Option<String> {
+    let xdg_config = env::var_os(XDG_CONFIG_HOME).map(PathBuf::from)?;
+
+    let config_path = xdg_config.join(ERDTREE_DIR).join(ERDTREE_CONFIG_NAME);
+
+    fs::read_to_string(config_path).ok().or_else(|| {
+        let config_path = xdg_config.join(ERDTREE_CONFIG_NAME);
+        fs::read_to_string(config_path).ok()
+    })
+}
+
+/// Prepends "--\n" to the config string which is required for proper parsing by
+/// [`get_matches_from`].
+///
+/// [`get_matches_from`]: clap::builder::Command::get_matches_from
+fn prepend_arg_prefix(config: String) -> String {
+    format!("--\n{config}")
 }


### PR DESCRIPTION
Closes https://github.com/solidiquis/erdtree/issues/64 and https://github.com/solidiquis/erdtree/issues/63

## Additions

The configuration file can now be placed in more locations:
- `$ERDTREE_CONFIG_NAME`
- `$XDG_CONFIG_HOME/erdtree/.erdtreerc`
- `$XDG_CONFIG_HOME/.erdtreerc`
- `$HOME/.config/erdtree/.erdtreerc`
- `$HOME/.erdtreerc`
