### PR TITLE
chore(readme): add scoop, minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,23 +85,27 @@ Options:
 
 ## Installation
 
-### crate.io
+### crates.io
 
 1. Make sure you have [Rust and its toolchain](https://www.rust-lang.org/tools/install) installed.
 2. `$ cargo install erdtree`
-
-### NetBSD
-
-A package is available from the official repositories. To install it, simply run:
-
-```
-pkgin install erdtree
-```
 
 ### Homebrew-core
 
 ```
 $ brew install erdtree
+```
+
+### Scoop
+
+```
+$ scoop install erdtree
+```
+
+### NetBSD
+
+```
+$ pkgin install erdtree
 ```
 
 ### Releases


### PR DESCRIPTION
closes #36

merged into the main scoop repo as of ScoopInstaller/Main#4560

note that the [v1.5.2](https://github.com/solidiquis/erdtree/releases/tag/v1.5.2) release for windows has an inconsistent name with the previous releases or other binaries in the same release: `et-1.5.2...` as opposed to `et-v1.5.2...` which currently breaks auto-updating in the scoop package. looking at the workflow this seems like a bug and not an intentional change, but if it is intentional and will be used in future releases i will make a pr to adapt the scoop package. if it isn't intentional however, could you change the binary name in the v1.5.2 release so scoop can auto-update from v1.4.1 to v1.5.2?