### PR TITLE
default to num logical cpus rather than 4 threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "ignore",
  "indoc",
  "lscolors",
+ "num_cpus",
  "once_cell",
  "strip-ansi-escapes",
  "tempdir",
@@ -243,6 +244,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "856b5cb0902c2b6d65d5fd97dfa30f9b70c7538e770b98eab5ed52d8db923e01"
@@ -286,7 +296,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.0",
  "io-lifetimes",
  "rustix",
  "windows-sys",
@@ -352,6 +362,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ crossbeam = "0.8.2"
 filesize = "0.2.0"
 ignore = "0.4.2"
 lscolors = { version = "0.13.0", features = ["ansi_term"] }
+num_cpus = "1.15.0"
 once_cell = "1.17.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ A modern, vibrant, and multi-threaded file-tree visualizer and disk usage analyz
 If the chosen defaults don't meet your requirements and you don't want to bloat your shell configs with aliases, you can use a [configuration file](#configuration-file) instead.
 
 ## Usage
+
+**Note**: The amount of threads used by default is dependent upon how many logical CPUs available in your system.
+
 ```
 erdtree (et) is a multi-threaded filetree visualizer and disk usage analyzer.
 
@@ -75,7 +78,7 @@ Options:
   -s, --sort <SORT>              Sort-order to display directory content [possible values: name, size, size-rev]
       --dirs-first               Always sorts directories above files
   -S, --follow-links             Traverse symlink directories and consider their disk usage; disabled by default
-  -t, --threads <THREADS>        Number of threads to use [default: 4]
+  -t, --threads <THREADS>        Number of threads to use [default: 10]
       --suppress-size            Omit disk usage from output; disabled by default
       --size-left                Show the size on the left, decimal aligned
       --no-config                Don't read configuration file

--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -92,8 +92,8 @@ pub struct Context {
     #[arg(short = 'S', long)]
     pub follow_links: bool,
 
-    /// Number of threads to use
-    #[arg(short, long, default_value_t = 4)]
+    /// Number of threads to use; defaults to number of logical cores available
+    #[arg(short, long, default_value_t = num_cpus::get())]
     pub threads: usize,
 
     /// Omit disk usage from output; disabled by default


### PR DESCRIPTION
### Additions

Rather than defaulting to an arbitrary number of threads for parallel traversal this will have it default to the number of logical CPU units you have available on your system. 