### PR TITLE
fix: check filetype before extension

### DIFF
--- a/src/render/tree/node.rs
+++ b/src/render/tree/node.rs
@@ -197,11 +197,11 @@ impl Node {
 
         let path = self.symlink_target_path().unwrap_or_else(|| self.path());
 
-        if let Some(icon) = path.extension().and_then(icon_from_ext) {
+        if let Some(icon) = self.file_type().and_then(icon_from_file_type) {
             return Some(self.stylize(icon));
         }
 
-        if let Some(icon) = self.file_type().and_then(icon_from_file_type) {
+        if let Some(icon) = path.extension().and_then(icon_from_ext) {
             return Some(self.stylize(icon));
         }
 


### PR DESCRIPTION
useful for example when a directory's name ends with an extension

- before:

![18_03_2023-17_07_WindowsTerminal_NKpCF8U](https://user-images.githubusercontent.com/36301891/226114362-c161ead6-3477-4555-bee9-e48cb80af49a.png)

- after:

![18_03_2023-17_07_WindowsTerminal_Zbb83Qq](https://user-images.githubusercontent.com/36301891/226114370-fd38b15a-cd81-408c-a88d-3a1c8f2bba5a.png)
