### PR TITLE
fix issue where ansi escapes were being printed raw on windows

### DIFF
--- a/src/render/tree/ui.rs
+++ b/src/render/tree/ui.rs
@@ -38,6 +38,9 @@ pub type ThemesMap = HashMap<&'static str, String>;
 
 /// Initializes both [LS_COLORS] and [THEME].
 pub fn init() {
+    #[cfg(windows)]
+    ansi_term::enable_ansi_support();
+
     init_ls_colors();
     init_themes();
 }


### PR DESCRIPTION
### Bug Fixes
- https://github.com/solidiquis/erdtree/issues/66

Shoutout to @fawni for figuring this one out `(♡ヮ♡)`