### PR TITLE
Fix windows can not recognize the tag version when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,13 +42,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
-
-    - name: Set the version
-      id: version
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -82,18 +78,25 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         UPLOADTOOL_ISPRERELEASE: true
+        VERSION: ${{  github.ref_name }}
       run: |
         curl -L https://github.com/probonopd/uploadtool/raw/master/upload.sh --output upload.sh
         mv target/${{ matrix.target }}/release/et et
-        tar -cavf et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.tar.gz et CHANGELOG.md README.md LICENSE
-        bash upload.sh et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.tar.gz
+        tar -cavf et-${VERSION}-${{ matrix.target }}.tar.gz et CHANGELOG.md README.md LICENSE
+        bash upload.sh et-${VERSION}-${{ matrix.target }}.tar.gz
     
-    - name: Upload files (only for Windows)
+    - name: Rename files (only for Windows)
       if: matrix.target == 'x86_64-pc-windows-msvc'
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        UPLOADTOOL_ISPRERELEASE: true
+        VERSION: ${{ github.ref_name }}
       run: |
-        curl -L https://github.com/probonopd/uploadtool/raw/master/upload.sh --output upload.sh
-        mv target/${{ matrix.target }}/release/et.exe et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.exe
-        bash upload.sh et-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.exe
+        mkdir output/
+        mv target/${{ matrix.target }}/release/et.exe output/et-$env:VERSION-${{ matrix.target }}.exe
+    
+    - name: Upload files (only for Windows)
+      uses: ncipollo/release-action@v1
+      if: matrix.target == 'x86_64-pc-windows-msvc'
+      with:
+        allowUpdates: true
+        artifacts: "output/*"
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[Github Action Log](https://github.com/Tlntin/erdtree/actions/runs/4468692975/jobs/7849771800)
[Release url](https://github.com/Tlntin/erdtree/releases/tag/v1.6.0)

The screenshot is as follows, the windows version number is normal.

![image](https://user-images.githubusercontent.com/28218658/226355438-ad76cc7e-7ec0-4627-9d9a-c1da94b87648.png)
