### PR TITLE
Swap `num_cpus` for `available_parallelism`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,6 @@ dependencies = [
  "indextree",
  "indoc",
  "lscolors",
- "num_cpus",
  "once_cell",
  "strip-ansi-escapes",
  "tempfile",
@@ -258,15 +257,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -315,7 +305,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e86b86ae312accbf05ade23ce76b625e0e47a255712b7414037385a1c05380"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.45.0",
 ]
@@ -326,7 +316,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.45.0",
@@ -392,16 +382,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi 0.2.6",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ filesize = "0.2.0"
 ignore = "0.4.2"
 indextree = "4.6.0"
 lscolors = { version = "0.13.0", features = ["ansi_term"] }
-num_cpus = "1.15.0"
 once_cell = "1.17.0"
 
 [dev-dependencies]

--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -11,7 +11,9 @@ use std::{
     error::Error as StdError,
     ffi::{OsStr, OsString},
     fmt::{self, Display},
+    num::NonZeroUsize,
     path::{Path, PathBuf},
+    thread::available_parallelism,
     usize,
 };
 
@@ -21,6 +23,12 @@ pub mod config;
 /// Unit tests for [Context]
 #[cfg(test)]
 mod test;
+
+fn default_threads() -> usize {
+    available_parallelism()
+        .unwrap_or_else(|_| NonZeroUsize::new(1).unwrap())
+        .get()
+}
 
 /// Defines the CLI.
 #[derive(Parser, Debug)]
@@ -93,7 +101,7 @@ pub struct Context {
     pub follow_links: bool,
 
     /// Number of threads to use; defaults to number of logical cores available
-    #[arg(short, long, default_value_t = num_cpus::get())]
+    #[arg(short, long, default_value_t = { default_threads() })]
     pub threads: usize,
 
     /// Omit disk usage from output; disabled by default

--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -24,12 +24,6 @@ pub mod config;
 #[cfg(test)]
 mod test;
 
-fn default_threads() -> usize {
-    available_parallelism()
-        .unwrap_or_else(|_| NonZeroUsize::new(1).unwrap())
-        .get()
-}
-
 /// Defines the CLI.
 #[derive(Parser, Debug)]
 #[command(name = "erdtree")]
@@ -101,7 +95,7 @@ pub struct Context {
     pub follow_links: bool,
 
     /// Number of threads to use; defaults to number of logical cores available
-    #[arg(short, long, default_value_t = { default_threads() })]
+    #[arg(short, long, default_value_t = Context::default_threads())]
     pub threads: usize,
 
     /// Omit disk usage from output; disabled by default
@@ -185,6 +179,12 @@ impl Context {
         }
 
         Context::from_arg_matches(&user_args).map_err(|e| Error::ArgParse(e))
+    }
+
+    fn default_threads() -> usize {
+        available_parallelism()
+            .unwrap_or_else(|_| NonZeroUsize::new(1).unwrap())
+            .get()
     }
 
     /// Returns reference to the path of the root directory to be traversed.


### PR DESCRIPTION
`num_cpus` shouldn't be needed since `available_parallelism()` has been stable since Rust 1.59