### PR TITLE
Fix the problem that test actions cannot upload windows binary files, add the function of custom form to set tag version.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,12 @@
 name: Test App With Cache
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "tag version"
+        required: true
+        default: "v0.0.1"
 
 jobs:
   publish:
@@ -75,25 +80,32 @@ jobs:
         command: build
         args: --target ${{ matrix.target }} --release --locked
     
-    - name: Upload files (only for Mac/Linux)
+    - name: Rename files (only for Mac/Linux)
       if: matrix.target != 'x86_64-pc-windows-msvc'
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        UPLOADTOOL_ISPRERELEASE: true
+        VERSION: ${{ inputs.version }}
       run: |
-        curl -L https://github.com/probonopd/uploadtool/raw/master/upload.sh --output upload.sh
-        mv target/${{ matrix.target }}/release/et et-${{ matrix.target }}
-        bash upload.sh et-${{ matrix.target }}
+        mkdir output/
+        mv target/${{ matrix.target }}/release/et et
+        tar -cavf output/et-${VERSION}-${{ matrix.target }}.tar.gz et CHANGELOG.md README.md LICENSE
     
-    - name: Upload files (only for Windows)
+    - name: Rename files (only for Windows)
       if: matrix.target == 'x86_64-pc-windows-msvc'
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        UPLOADTOOL_ISPRERELEASE: true
+        VERSION: ${{ inputs.version }}
       run: |
-        curl -L https://github.com/probonopd/uploadtool/raw/master/upload.sh --output upload.sh
-        mv target/${{ matrix.target }}/release/et.exe et-${{ matrix.target }}.exe
-        bash upload.sh et-${{ matrix.target }}.exe
+        mkdir output/
+        mv target/${{ matrix.target }}/release/et.exe output/et-$env:VERSION-${{ matrix.target }}.exe
+    
+    - name: Upload files
+      # arg info: https://github.com/ncipollo/release-action#release-action
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true
+        prerelease: true
+        artifacts: "output/*"
+        tag: ${{ inputs.version }}
+        token: ${{ secrets.GITHUB_TOKEN }}
     
     
     - name: rust cache store

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,6 @@ jobs:
       with:
         fetch-depth: 1
 
-    - name: Set the version
-      id: version
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
Fix the problem that test actions cannot upload windows binary files
add the function of custom form to set tag version.

![image](https://user-images.githubusercontent.com/28218658/226617544-c20aaacd-2a55-4c9a-a4f0-8fa302a7dfa9.png)
By default, pre release will be generated, if you want change it, you can refer to this [link](https://github.com/ncipollo/release-action#release-action)
![image](https://user-images.githubusercontent.com/28218658/226618016-5582ecfd-0c94-4bbd-a308-ef6f0440a6ff.png)

