### PR TITLE
Implement dirs-only option

### DIFF
--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -113,6 +113,10 @@ pub struct Context {
     #[arg(long)]
     /// Print completions for a given shell to stdout
     pub completions: Option<clap_complete::Shell>,
+
+    #[arg(short = 'D', long)]
+    /// Only show directories
+    pub dirs_only: bool,
 }
 
 impl Context {

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -89,6 +89,9 @@ impl Tree {
                 let mut root_id = None;
 
                 while let Ok(TraversalState::Ongoing(node)) = rx.recv() {
+                    if ctx.dirs_only && !node.is_dir() {
+                        continue
+                    }
                     if node.is_dir() {
                         let node_path = node.path();
 

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -89,9 +89,6 @@ impl Tree {
                 let mut root_id = None;
 
                 while let Ok(TraversalState::Ongoing(node)) = rx.recv() {
-                    if ctx.dirs_only && !node.is_dir() {
-                        continue
-                    }
                     if node.is_dir() {
                         let node_path = node.path();
 
@@ -252,6 +249,9 @@ impl Display for Tree {
             ctx: &Context,
             f: &mut Formatter<'_>,
         ) -> fmt::Result {
+            if ctx.dirs_only && !node.is_dir() {
+                return Ok(());
+            }
             if ctx.size_left && !ctx.suppress_size {
                 node.display_size_left(f, base_prefix, ctx)?;
             } else {

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -70,7 +70,7 @@ impl Tree {
 
     /// Parallel traversal of the root directory and its contents. Parallel traversal relies on
     /// `WalkParallel`. Any filesystem I/O or related system calls are expected to occur during
-    /// parallel traversal; post-processing post-processing of all directory entries should
+    /// parallel traversal; post-processing of all directory entries should
     /// be completely CPU-bound.
     fn traverse(ctx: &Context) -> TreeResult<(Arena<Node>, NodeId)> {
         let walker = WalkParallel::try_from(ctx)?;
@@ -83,7 +83,7 @@ impl Tree {
                 // Key represents path of parent directory and values represent children.
                 let mut branches: HashMap<PathBuf, Vec<NodeId>> = HashMap::new();
 
-                // Set used to prevent double counting hard-links in the same file-tree hiearchy.
+                // Set used to prevent double counting hard-links in the same file-tree hierarchy.
                 let mut inodes = HashSet::new();
 
                 let mut root_id = None;

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -89,6 +89,9 @@ impl Tree {
                 let mut root_id = None;
 
                 while let Ok(TraversalState::Ongoing(node)) = rx.recv() {
+                    if ctx.dirs_only && !node.is_dir() {
+                        continue
+                    }
                     if node.is_dir() {
                         let node_path = node.path();
 
@@ -249,9 +252,6 @@ impl Display for Tree {
             ctx: &Context,
             f: &mut Formatter<'_>,
         ) -> fmt::Result {
-            if ctx.dirs_only && !node.is_dir() {
-                return Ok(());
-            }
             if ctx.size_left && !ctx.suppress_size {
                 node.display_size_left(f, base_prefix, ctx)?;
             } else {

--- a/tests/dirs_only.rs
+++ b/tests/dirs_only.rs
@@ -1,0 +1,24 @@
+use indoc::indoc;
+
+mod utils;
+
+#[test]
+fn level() {
+    assert_eq!(
+        utils::run_cmd(&[
+            "--sort",
+            "name",
+            "--no-config",
+            "--dirs-only",
+            "tests/data"
+        ]),
+        indoc!(
+            "
+            data 
+            ├─ dream_cycle 
+            ├─ lipsum 
+            └─ the_yellow_king"
+        ),
+        "Failed to print dirs-only."
+    )
+}

--- a/tests/dirs_only.rs
+++ b/tests/dirs_only.rs
@@ -5,19 +5,13 @@ mod utils;
 #[test]
 fn level() {
     assert_eq!(
-        utils::run_cmd(&[
-            "--sort",
-            "name",
-            "--no-config",
-            "--dirs-only",
-            "tests/data"
-        ]),
+        utils::run_cmd(&["--sort", "name", "--no-config", "--dirs-only", "tests/data"]),
         indoc!(
             "
-            data 
-            ├─ dream_cycle 
-            ├─ lipsum 
-            └─ the_yellow_king"
+            data (1.21 KiB)
+            ├─ dream_cycle (308 B)
+            ├─ lipsum (446 B)
+            └─ the_yellow_king (143 B)"
         ),
         "Failed to print dirs-only."
     )


### PR DESCRIPTION
When `dirs-only` is enabled every node other than a directory will be skipped, i.e. it is not shown in the output.

Closes #84.

**TODOs**

- [ ] Squash fixup commits