### PR TITLE
Reduce default thread count

### DIFF
--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -94,8 +94,8 @@ pub struct Context {
     #[arg(short = 'S', long)]
     pub follow_links: bool,
 
-    /// Number of threads to use; defaults to number of logical cores available
-    #[arg(short, long, default_value_t = Context::default_threads())]
+    /// Number of threads to use
+    #[arg(short, long, default_value_t = 3)]
     pub threads: usize,
 
     /// Omit disk usage from output; disabled by default
@@ -179,12 +179,6 @@ impl Context {
         }
 
         Context::from_arg_matches(&user_args).map_err(|e| Error::ArgParse(e))
-    }
-
-    fn default_threads() -> usize {
-        available_parallelism()
-            .unwrap_or_else(|_| NonZeroUsize::new(1).unwrap())
-            .get()
     }
 
     /// Returns reference to the path of the root directory to be traversed.


### PR DESCRIPTION
Setting default thread count to `available_parallelism` takes us way past the point of diminishing returns which is actually detrimental to performance.

`3` seems to be the sweet spot I've found across various SSDs and HDDs.

For more information about how parallelism affects disk reads checkout [this link](https://pkolaczk.github.io/disk-parallelism/).

```
┌─ code
└ 🧋 time et -l 1 -H -i -t 1 --no-config
code (125.46 GiB)
├─ ruby (32.87 KiB)
├─ advent_of_code (3.81 MiB)
├─ lua (21.02 KiB)
├─ homebrew-tap (33.93 KiB)
├─ rust (6.52 GiB)
├─ projects (118.94 GiB)
├─ test (25.55 KiB)
├─ .DS_Store (6.00 KiB)
└─ golf (2.30 KiB)

et -l 1 -H -i -t 1 --no-config  1.06s user 0.88s system 121% cpu 1.597 total
┌─ code
└ 🧋 time et -l 1 -H -i -t 2 --no-config
code (125.46 GiB)
├─ ruby (32.87 KiB)
├─ advent_of_code (3.81 MiB)
├─ lua (21.02 KiB)
├─ rust (6.52 GiB)
├─ homebrew-tap (33.93 KiB)
├─ projects (118.94 GiB)
├─ .DS_Store (6.00 KiB)
├─ test (25.55 KiB)
└─ golf (2.30 KiB)

et -l 1 -H -i -t 2 --no-config  1.03s user 1.02s system 209% cpu 0.979 total
┌─ code
└ 🧋 time et -l 1 -H -i -t 3 --no-config
code (125.46 GiB)
├─ ruby (32.87 KiB)
├─ advent_of_code (3.81 MiB)
├─ lua (21.02 KiB)
├─ homebrew-tap (33.93 KiB)
├─ projects (118.94 GiB)
├─ rust (6.52 GiB)
├─ test (25.55 KiB)
├─ .DS_Store (6.00 KiB)
└─ golf (2.30 KiB)

et -l 1 -H -i -t 3 --no-config  1.10s user 1.14s system 281% cpu 0.796 total
┌─ code
└ 🧋 time et -l 1 -H -i -t 4 --no-config
code (125.46 GiB)
├─ ruby (32.87 KiB)
├─ lua (21.02 KiB)
├─ advent_of_code (3.81 MiB)
├─ rust (6.52 GiB)
├─ homebrew-tap (33.93 KiB)
├─ projects (118.94 GiB)
├─ .DS_Store (6.00 KiB)
├─ golf (2.30 KiB)
└─ test (25.55 KiB)

et -l 1 -H -i -t 4 --no-config  1.19s user 1.61s system 339% cpu 0.828 total
┌─ code
└ 🧋 time et -l 1 -H -i -t 5 --no-config
code (125.46 GiB)
├─ ruby (32.87 KiB)
├─ advent_of_code (3.81 MiB)
├─ lua (21.02 KiB)
├─ homebrew-tap (33.93 KiB)
├─ rust (6.52 GiB)
├─ projects (118.94 GiB)
├─ test (25.55 KiB)
├─ .DS_Store (6.00 KiB)
└─ golf (2.30 KiB)

et -l 1 -H -i -t 5 --no-config  1.29s user 2.05s system 399% cpu 0.836 total
┌─ code
└ 🧋 time et -l 1 -H -i -t 6 --no-config
code (125.46 GiB)
├─ ruby (32.87 KiB)
├─ lua (21.02 KiB)
├─ rust (6.52 GiB)
├─ .DS_Store (6.00 KiB)
├─ homebrew-tap (33.93 KiB)
├─ advent_of_code (3.81 MiB)
├─ projects (118.94 GiB)
├─ test (25.55 KiB)
└─ golf (2.30 KiB)

et -l 1 -H -i -t 6 --no-config  1.35s user 2.56s system 463% cpu 0.844 total
```