### PR TITLE
dirs-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Options:
   -g, --glob <GLOB>                Include or exclude files using glob patterns
       --iglob <IGLOB>              Include or exclude files using glob patterns; case insensitive
       --glob-case-insensitive      Process all glob patterns case insensitively
-  -H, --hidden                     Show hidden files; disabled by default
+  -H, --hidden                     Show hidden files
       --ignore-git                 Disable traversal of .git directory when traversing hidden files; disabled by default
-  -I, --icons                      Display file icons; disabled by default
-  -i, --ignore-git-ignore          Ignore .gitignore; disabled by default
+  -I, --icons                      Display file icons
+  -i, --ignore-git-ignore          Ignore .gitignore
   -l, --level <NUM>                Maximum depth to display
   -n, --scale <NUM>                Total number of digits after the decimal to display for disk usage [default: 2]
   -p, --prefix <PREFIX>            Display disk usage as binary or SI units [default: bin] [possible values: bin, si]
@@ -82,12 +82,13 @@ Options:
       --file-name                  Print file-name in report as opposed to full path
   -s, --sort <SORT>                Sort-order to display directory content [default: none] [possible values: name, size, size-rev, none]
       --dirs-first                 Always sorts directories above files
-  -S, --follow-links               Traverse symlink directories and consider their disk usage; disabled by default
+  -S, --follow-links               Traverse symlink directories and consider their disk usage
   -t, --threads <THREADS>          Number of threads to use [default: 3]
-      --suppress-size              Omit disk usage from output; disabled by default
+      --completions <COMPLETIONS>  Print completions for a given shell to stdout [possible values: bash, elvish, fish, powershell, zsh]
+      --dirs-only                  Only print directories
+      --suppress-size              Omit disk usage from output
       --size-left                  Show the size on the left, decimal aligned
       --no-config                  Don't read configuration file
-      --completions <COMPLETIONS>  Print completions for a given shell to stdout [possible values: bash, elvish, fish, powershell, zsh]
   -h, --help                       Print help (see more with '--help')
   -V, --version                    Print version
 ```

--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -45,7 +45,7 @@ pub struct Context {
     #[arg(long)]
     glob_case_insensitive: bool,
 
-    /// Show hidden files; disabled by default
+    /// Show hidden files
     #[arg(short = 'H', long)]
     pub hidden: bool,
 
@@ -53,11 +53,11 @@ pub struct Context {
     #[arg(long)]
     ignore_git: bool,
 
-    /// Display file icons; disabled by default
+    /// Display file icons
     #[arg(short = 'I', long)]
     pub icons: bool,
 
-    /// Ignore .gitignore; disabled by default
+    /// Ignore .gitignore
     #[arg(short, long)]
     pub ignore_git_ignore: bool,
 
@@ -97,7 +97,7 @@ pub struct Context {
     #[arg(long)]
     dirs_first: bool,
 
-    /// Traverse symlink directories and consider their disk usage; disabled by default
+    /// Traverse symlink directories and consider their disk usage
     #[arg(short = 'S', long)]
     pub follow_links: bool,
 
@@ -105,7 +105,15 @@ pub struct Context {
     #[arg(short, long, default_value_t = 3)]
     pub threads: usize,
 
-    /// Omit disk usage from output; disabled by default
+    #[arg(long)]
+    /// Print completions for a given shell to stdout
+    pub completions: Option<clap_complete::Shell>,
+
+    /// Only print directories
+    #[arg(long)]
+    pub dirs_only: bool,
+
+    /// Omit disk usage from output
     #[arg(long)]
     pub suppress_size: bool,
 
@@ -116,10 +124,6 @@ pub struct Context {
     /// Don't read configuration file
     #[arg(long)]
     pub no_config: bool,
-
-    #[arg(long)]
-    /// Print completions for a given shell to stdout
-    pub completions: Option<clap_complete::Shell>,
 }
 
 impl Context {

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -135,6 +135,10 @@ impl Tree {
                     Self::prune_directories(root, &mut tree);
                 }
 
+                if ctx.dirs_only {
+                    Self::filter_directories(root, &mut tree);
+                }
+
                 Ok::<(Arena<Node>, NodeId), Error>((tree, root))
             });
 
@@ -225,6 +229,21 @@ impl Tree {
         }
 
         Self::prune_directories(root_id, tree);
+    }
+
+    /// Filter for only directories.
+    fn filter_directories(root: NodeId, tree: &mut Arena<Node>) {
+        let mut to_detach = vec![];
+
+        for descendant_id in root.descendants(tree).skip(1) {
+            if !tree[descendant_id].get().is_dir() {
+                to_detach.push(descendant_id);
+            }
+        }
+
+        for descendant_id in to_detach {
+            descendant_id.detach(tree);
+        }
     }
 }
 

--- a/tests/dirs_only.rs
+++ b/tests/dirs_only.rs
@@ -1,0 +1,17 @@
+use indoc::indoc;
+
+mod utils;
+
+#[test]
+fn dirs_only() {
+    assert_eq!(
+        utils::run_cmd(&["--dirs-only", "--sort", "name", "--no-config", "tests/data"]),
+        indoc!(
+            "
+            data (1.21 KiB)
+            ├─ dream_cycle (308 B)
+            ├─ lipsum (446 B)
+            └─ the_yellow_king (143 B)"
+        )
+    )
+}


### PR DESCRIPTION
Closes https://github.com/solidiquis/erdtree/issues/84

### Additions

- `--dirs-only` used to print only directories.