### PR TITLE
add clap requires to flags that depent on --report

### DIFF
--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -86,11 +86,11 @@ pub struct Context {
     pub report: bool,
 
     /// Print human-readable disk usage in report
-    #[arg(long)]
+    #[arg(long, requires = "report")]
     pub human: bool,
 
     /// Print file-name in report as opposed to full path
-    #[arg(long)]
+    #[arg(long, requires = "report")]
     pub file_name: bool,
 
     /// Sort-order to display directory content

--- a/tests/report.rs
+++ b/tests/report.rs
@@ -73,3 +73,15 @@ fn report_with_level() {
         )
     )
 }
+
+#[test]
+#[should_panic]
+fn report_requires_human() {
+    utils::run_cmd(&["--human"]);
+}
+
+#[test]
+#[should_panic]
+fn report_requires_file_name() {
+    utils::run_cmd(&["--file-name"]);
+}


### PR DESCRIPTION
While playing around with `et` I was wondering why `--human` had no effect until I noticed that it's supposed to be used in combination with `--report`.
This adds the `requires` tag to `--human` and `--file-name` in order to print a useful error message when these options are used without `--report`.

A better alternative approach would be to implement something like: `et --report=human,file-name`, but I think that's only possible with clap's Builder API.