### PR TITLE
Prevent panic when `--prune` is used with `--glob` which results in empty match set

### DIFF
--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -211,7 +211,7 @@ impl Tree {
     fn prune_directories(root_id: NodeId, tree: &mut Arena<Node>) {
         let mut to_prune = vec![];
 
-        for node_id in root_id.descendants(tree) {
+        for node_id in root_id.descendants(tree).skip(1) {
             let node = tree[node_id].get();
 
             if !node.is_dir() {

--- a/tests/glob.rs
+++ b/tests/glob.rs
@@ -24,7 +24,7 @@ fn glob() {
             ├─ nylarlathotep.txt (100 B)
             └─ the_yellow_king"
         )
-    )
+    );
 }
 
 #[test]

--- a/tests/prune.rs
+++ b/tests/prune.rs
@@ -24,5 +24,20 @@ fn prune() {
             ├─ nemesis.txt (161 B)
             └─ nylarlathotep.txt (100 B)"
         )
+    );
+
+    assert_eq!(
+        utils::run_cmd(&[
+            "--sort",
+            "name",
+            "--glob",
+            "something_that_does_not_exist.txt",
+            "--prune",
+            "tests/data"
+        ]),
+        indoc!(
+            "
+            data"
+        )
     )
 }


### PR DESCRIPTION
Closes https://github.com/solidiquis/erdtree/issues/115