### PR TITLE
refactor: :recycle: Update "hash" macro for more match like expressions

### DIFF
--- a/src/render/styles/mod.rs
+++ b/src/render/styles/mod.rs
@@ -100,14 +100,10 @@ fn init_themes() {
 
     let du_theme = hash! {
         "B" => Color::Cyan,
-        "KB" => Color::Yellow,
-        "KiB" => Color::Yellow,
-        "MB" => Color::Green,
-        "MiB" => Color::Green,
-        "GB" => Color::Red,
-        "GiB" => Color::Red,
-        "TB" => Color::Blue,
-        "TiB" => Color::Blue
+        "KB" | "KiB" => Color::Yellow,
+        "MB" | "MiB" => Color::Green,
+        "GB" | "GiB" => Color::Red,
+        "TB" | "TiB" => Color::Blue
     };
 
     DU_THEME.set(du_theme).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,15 @@ use std::{borrow::ToOwned, cmp::Eq, collections::HashSet, hash::Hash};
 #[macro_export]
 /// Ruby-like way to crate a hashmap.
 macro_rules! hash {
+    ( $( $( $k:literal)|* => $v:expr ),* ) => {
+        {
+            let mut hash = std::collections::HashMap::new();
+            $(
+                $( hash.insert($k, $v); )*
+            )*
+            hash
+        }
+    };
     ( $( $k:expr => $v:expr ),* ) => {
         {
             let mut hash = std::collections::HashMap::new();


### PR DESCRIPTION
The hash! Macro has been updated to accept the usage of the vertical bars “|” for literals. This allows conciser, more “match like” usage.