### PR TITLE
Feature/regex globbing file type

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ mod render;
 /// Determine if standard streams are connected to a tty.
 mod tty;
 
-/// Common utilities.
+/// Common utilities across all modules.
 mod utils;
 
 fn main() -> ExitCode {

--- a/src/render/context/error.rs
+++ b/src/render/context/error.rs
@@ -1,6 +1,5 @@
 use clap::Error as ClapError;
 use ignore::Error as IgnoreError;
-use regex::Error as RegexError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -12,12 +11,6 @@ pub enum Error {
 
     #[error("{0}")]
     IgnoreError(#[from] IgnoreError),
-
-    #[error("{0}")]
-    InvalidRegularExpression(#[from] RegexError),
-
-    #[error("Regular expressions search is disabled due to use of '--glob' or '--iglob'")]
-    RegexDisabled,
 
     #[error("Missing '--pattern' argument")]
     PatternNotProvided,

--- a/src/render/context/error.rs
+++ b/src/render/context/error.rs
@@ -10,6 +10,9 @@ pub enum Error {
     #[error("A configuration file was found but failed to parse: {0}")]
     Config(#[source] ClapError),
 
+    #[error("No glob was provided")]
+    EmptyGlob,
+
     #[error("{0}")]
     IgnoreError(#[from] IgnoreError),
 

--- a/src/render/context/error.rs
+++ b/src/render/context/error.rs
@@ -1,5 +1,6 @@
 use clap::Error as ClapError;
 use ignore::Error as IgnoreError;
+use regex::Error as RegexError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -11,6 +12,9 @@ pub enum Error {
 
     #[error("{0}")]
     IgnoreError(#[from] IgnoreError),
+
+    #[error("{0}")]
+    InvalidRegularExpression(#[from] RegexError),
 
     #[error("Missing '--pattern' argument")]
     PatternNotProvided,

--- a/src/render/context/file.rs
+++ b/src/render/context/file.rs
@@ -1,0 +1,17 @@
+use clap::ValueEnum;
+
+/// File-types found in both Unix and Windows.
+#[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[allow(clippy::module_name_repetitions)]
+pub enum FileType {
+    /// A regular file.
+    #[default]
+    File,
+
+    /// A directory.
+    Dir,
+
+    /// A symlink.
+    Link,
+}
+

--- a/src/render/context/file.rs
+++ b/src/render/context/file.rs
@@ -14,4 +14,3 @@ pub enum FileType {
     /// A symlink.
     Link,
 }
-

--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -328,15 +328,22 @@ impl Context {
         let mut negated_glob = false;
 
         let overrides = if !self.glob && !self.iglob {
-            builder.build()?
+            // Shouldn't really ever be hit but placing here as a safeguard.
+            return Err(Error::EmptyGlob)
         } else {
             if self.iglob {
                 builder.case_insensitive(true).unwrap();
             }
 
             if let Some(ref glob) = self.pattern {
-                negated_glob = glob.trim_start().starts_with("!");
-                builder.add(glob.trim_start_matches('!'))?;
+                let trim = glob.trim_start();
+                negated_glob = trim.starts_with("!");
+
+                if negated_glob {
+                    builder.add(trim.trim_start_matches('!'))?;
+                } else {
+                    builder.add(trim)?;
+                }
             }
 
             builder.build()?

--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -325,10 +325,6 @@ impl Context {
     ) -> Result<Box<dyn Fn(&DirEntry) -> bool + Send + Sync + 'static>, Error> {
         let mut builder = OverrideBuilder::new(self.dir());
 
-        if self.no_git {
-            builder.add("!.git")?;
-        }
-
         let mut negated_glob = false;
 
         let overrides = if !self.glob && !self.iglob {

--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -3,7 +3,7 @@ use crate::tty;
 use clap::{parser::ValueSource, ArgMatches, CommandFactory, FromArgMatches, Id, Parser};
 use error::Error;
 use ignore::{
-    overrides::OverrideBuilder,
+    overrides::{OverrideBuilder, Override},
     DirEntry,
 };
 use regex::Regex;
@@ -363,6 +363,17 @@ impl Context {
         });
 
         Ok(predicate)
+    }
+
+    /// Special override to toggle the visibility of the git directory.
+    pub fn no_git_override(&self) -> Result<Override, Error> {
+        let mut builder = OverrideBuilder::new(self.dir());
+
+        if self.no_git {
+            builder.add("!.git")?;
+        }
+        
+        Ok(builder.build()?)
     }
 
     /// Setter for `max_du_width` to inform formatters what the width of the disk usage column

--- a/src/render/disk_usage/file_size.rs
+++ b/src/render/disk_usage/file_size.rs
@@ -112,7 +112,7 @@ impl FileSize {
 
     /// Returns a placeholder or empty string.
     pub fn placeholder(ctx: &Context) -> String {
-        if ctx.suppress_size {
+        if ctx.suppress_size || ctx.max_du_width == 0 {
             String::new()
         } else {
             let (placeholder, extra_padding) = get_placeholder_style().map_or_else(

--- a/src/render/disk_usage/file_size.rs
+++ b/src/render/disk_usage/file_size.rs
@@ -133,7 +133,7 @@ impl FileSize {
     }
 
     /// Base amount of padding to use for the placeholder.
-    fn placeholder_padding(ctx: &Context) -> usize {
+    const fn placeholder_padding(ctx: &Context) -> usize {
         let unit_len = match ctx.unit {
             PrefixKind::Bin => 3,
             PrefixKind::Si => 2,

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -1,10 +1,6 @@
 use crate::{
     fs::inode::Inode,
-    render::{
-        context::Context,
-        disk_usage::file_size::FileSize,
-        styles,
-    },
+    render::{context::Context, disk_usage::file_size::FileSize, styles},
 };
 use count::FileCount;
 use error::Error;

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -375,6 +375,7 @@ impl TryFrom<&Context> for WalkParallel {
             .follow_links(ctx.follow)
             .git_ignore(!ctx.no_ignore)
             .hidden(!ctx.hidden)
+            .overrides(ctx.no_git_override()?)
             .threads(ctx.threads);
 
         if ctx.pattern.is_some() {

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -1,6 +1,10 @@
 use crate::{
     fs::inode::Inode,
-    render::{context::Context, disk_usage::file_size::FileSize, styles},
+    render::{
+        context::{file::FileType, Context},
+        disk_usage::file_size::FileSize,
+        styles,
+    },
 };
 use count::FileCount;
 use error::Error;
@@ -169,7 +173,7 @@ where
                     ctx,
                 );
 
-                if ctx.prune {
+                if ctx.prune || ctx.file_type != Some(FileType::Dir) {
                     Self::prune_directories(root, &mut tree);
                 }
 

--- a/src/render/tree/node/display.rs
+++ b/src/render/tree/node/display.rs
@@ -179,7 +179,7 @@ mod presenters {
             Node::style_sym_permissions(&mode, false)
         };
 
-        let datetime = match ctx.time {
+        let datetime = match ctx.time() {
             Stamp::Created => node.created(),
             Stamp::Accessed => node.accessed(),
             Stamp::Modified => node.modified(),

--- a/tests/glob.rs
+++ b/tests/glob.rs
@@ -15,16 +15,15 @@ fn glob() {
         ]),
         indoc!(
             "1.07 KiB data
-               308   B ├─ dream_cycle
-               308   B │  └─ polaris.txt
-               446   B ├─ lipsum
-               446   B │  └─ lipsum.txt
-                83   B ├─ necronomicon.txt
-               161   B ├─ nemesis.txt
-               100   B ├─ nylarlathotep.txt
-                     - └─ the_yellow_king
+            308   B ├─ dream_cycle
+            308   B │  └─ polaris.txt
+            446   B ├─ lipsum
+            446   B │  └─ lipsum.txt
+             83   B ├─ necronomicon.txt
+            161   B ├─ nemesis.txt
+            100   B └─ nylarlathotep.txt
 
-           3 directories, 5 files"
+        2 directories, 5 files"
         )
     );
 }
@@ -42,12 +41,10 @@ fn glob_negative() {
         ]),
         indoc!(
             "143   B data
-                  - ├─ dream_cycle
-                  - ├─ lipsum
             143   B └─ the_yellow_king
             143   B    └─ cassildas_song.md
 
-        3 directories, 1 file"
+        1 directory, 1 file"
         )
     )
 }
@@ -65,43 +62,15 @@ fn glob_case_insensitive() {
         ]),
         indoc!(
             "1.07 KiB data
-                308   B ├─ dream_cycle
-                308   B │  └─ polaris.txt
-                446   B ├─ lipsum
-                446   B │  └─ lipsum.txt
-                 83   B ├─ necronomicon.txt
-                161   B ├─ nemesis.txt
-                100   B ├─ nylarlathotep.txt
-                      - └─ the_yellow_king
+            308   B ├─ dream_cycle
+            308   B │  └─ polaris.txt
+            446   B ├─ lipsum
+            446   B │  └─ lipsum.txt
+             83   B ├─ necronomicon.txt
+            161   B ├─ nemesis.txt
+            100   B └─ nylarlathotep.txt
 
-            3 directories, 5 files"
-        )
-    )
-}
-
-#[test]
-fn iglob() {
-    assert_eq!(
-        utils::run_cmd(&[
-            "--sort",
-            "name",
-            "--iglob",
-            "--pattern",
-            "*.TXT",
-            "tests/data"
-        ]),
-        indoc!(
-            "1.07 KiB data
-                308   B ├─ dream_cycle
-                308   B │  └─ polaris.txt
-                446   B ├─ lipsum
-                446   B │  └─ lipsum.txt
-                 83   B ├─ necronomicon.txt
-                161   B ├─ nemesis.txt
-                100   B ├─ nylarlathotep.txt
-                      - └─ the_yellow_king
-
-            3 directories, 5 files"
+        2 directories, 5 files"
         )
     )
 }
@@ -131,7 +100,7 @@ fn glob_with_filetype() {
 
 #[test]
 #[should_panic]
-fn glob_empty_set() {
+fn glob_empty_set_dir() {
     utils::run_cmd(&[
         "--sort",
         "name",
@@ -140,6 +109,19 @@ fn glob_empty_set() {
         "*.txt",
         "--file-type",
         "dir",
+        "tests/data",
+    ]);
+}
+
+#[test]
+#[should_panic]
+fn glob_empty_set_file() {
+    utils::run_cmd(&[
+        "--sort",
+        "name",
+        "--glob",
+        "--pattern",
+        "*weewoo*",
         "tests/data",
     ]);
 }

--- a/tests/glob.rs
+++ b/tests/glob.rs
@@ -105,3 +105,41 @@ fn iglob() {
         )
     )
 }
+
+#[test]
+fn glob_with_filetype() {
+    assert_eq!(
+        utils::run_cmd(&[
+            "--sort",
+            "name",
+            "--glob",
+            "--pattern",
+            "dream*",
+            "--file-type",
+            "dir",
+            "tests/data"
+        ]),
+        indoc!(
+            "308   B data
+            308   B └─ dream_cycle
+            308   B    └─ polaris.txt
+
+        1 directory, 1 file"
+        )
+    )
+}
+
+#[test]
+#[should_panic]
+fn glob_empty_set() {
+    utils::run_cmd(&[
+        "--sort",
+        "name",
+        "--glob",
+        "--pattern",
+        "*.txt",
+        "--file-type",
+        "dir",
+        "tests/data",
+    ]);
+}

--- a/tests/hardlink.rs
+++ b/tests/hardlink.rs
@@ -26,7 +26,7 @@ fn hardlink() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         out,
         indoc!(
-           "157   B hardlinks
+            "157   B hardlinks
             157   B ├─ curwin.hpl
             157   B └─ kadath.txt
 

--- a/tests/regex.rs
+++ b/tests/regex.rs
@@ -8,16 +8,15 @@ fn regex() {
         utils::run_cmd(&["--sort", "name", "--pattern", r"\.txt$", "tests/data"]),
         indoc!(
             "1.07 KiB data
-                308   B ├─ dream_cycle
-                308   B │  └─ polaris.txt
-                446   B ├─ lipsum
-                446   B │  └─ lipsum.txt
-                 83   B ├─ necronomicon.txt
-                161   B ├─ nemesis.txt
-                100   B ├─ nylarlathotep.txt
-                      - └─ the_yellow_king
+            308   B ├─ dream_cycle
+            308   B │  └─ polaris.txt
+            446   B ├─ lipsum
+            446   B │  └─ lipsum.txt
+             83   B ├─ necronomicon.txt
+            161   B ├─ nemesis.txt
+            100   B └─ nylarlathotep.txt
 
-            3 directories, 5 files"
+        2 directories, 5 files"
         )
     );
 
@@ -64,7 +63,7 @@ fn regex_file_type() {
 
 #[should_panic]
 #[test]
-fn regex_empty_set() {
+fn regex_empty_set_dir() {
     // Trying to look for a regular file when file type is specified to be directory should result
     // in an empty set which causes `main` to return an error.
     utils::run_cmd(&[
@@ -76,6 +75,14 @@ fn regex_empty_set() {
         "dir",
         "tests/data",
     ]);
+}
+
+#[should_panic]
+#[test]
+fn regex_empty_set_file() {
+    // Trying to look for a regular file when file type is specified to be directory should result
+    // in an empty set which causes `main` to return an error.
+    utils::run_cmd(&["--sort", "name", "--pattern", "weewoo", "tests/data"]);
 }
 
 #[should_panic]

--- a/tests/regex.rs
+++ b/tests/regex.rs
@@ -40,6 +40,44 @@ fn regex() {
     );
 }
 
+#[test]
+fn regex_file_type() {
+    assert_eq!(
+        utils::run_cmd(&[
+            "--sort",
+            "name",
+            "--pattern",
+            r"^dream.",
+            "--file-type",
+            "dir",
+            "tests/data"
+        ]),
+        indoc!(
+            "308   B data
+            308   B └─ dream_cycle
+            308   B    └─ polaris.txt
+
+        1 directory, 1 file"
+        )
+    );
+}
+
+#[should_panic]
+#[test]
+fn regex_empty_set() {
+    // Trying to look for a regular file when file type is specified to be directory should result
+    // in an empty set which causes `main` to return an error.
+    utils::run_cmd(&[
+        "--sort",
+        "name",
+        "--pattern",
+        r"\.md$",
+        "--file-type",
+        "dir",
+        "tests/data",
+    ]);
+}
+
 #[should_panic]
 #[test]
 fn invalid_regex() {


### PR DESCRIPTION
### Additions

Regex and glob based searching can now be applied to select file types: regular files, directories, or symlinks. If applying globs/regex to directories, directories that match along with all of their descendants will be displayed.

```
  -t, --file-type <FILE_TYPE>      Restrict regex or glob search to a particular file-type [possible values: file, dir, link]

```
<img width="759" alt="Screen Shot 2023-04-20 at 8 16 09 PM" src="https://user-images.githubusercontent.com/45523555/233532199-6c26bd77-6e61-4cda-97b9-1a2a6d032f65.png">
<img width="750" alt="Screen Shot 2023-04-20 at 8 15 21 PM" src="https://user-images.githubusercontent.com/45523555/233532203-27a33614-e6f3-4645-8a0a-763795cfb23c.png">

