### PR TITLE
refactor: :recycle: Applying Clippy lints

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -15,8 +15,7 @@
 /// assumptions that are valid only for this program, namely that all relevant grapheme clusters
 /// are at most sized to a single `char`, so truncating to any arbitrary length will always result
 /// in a coherent output.
-#[allow(clippy::module_name_repetitions)]
-pub trait AnsiEscaped: AsRef<str> {
+pub trait Escaped: AsRef<str> {
     fn truncate(&self, new_len: usize) -> String {
         let mut open_sequence = false;
         let mut resultant = String::new();
@@ -60,7 +59,7 @@ pub trait AnsiEscaped: AsRef<str> {
     }
 }
 
-impl AnsiEscaped for str {}
+impl Escaped for str {}
 
 #[test]
 fn truncate() {
@@ -68,7 +67,7 @@ fn truncate() {
 
     let control = Red.bold().paint("Hello").to_string();
     let base = format!("{}{}", Red.bold().paint("Hello World"), "!!!");
-    let trunc = <str as AnsiEscaped>::truncate(&base, 5);
+    let trunc = <str as Escaped>::truncate(&base, 5);
 
     assert_eq!(control, trunc);
 }

--- a/src/fs/permissions/class.rs
+++ b/src/fs/permissions/class.rs
@@ -2,8 +2,7 @@ use std::fmt::{self, Display};
 
 /// The set of permissions for a particular class i.e. user, group, or other.
 #[derive(Debug)]
-#[allow(clippy::module_name_repetitions)]
-pub struct ClassPermissions {
+pub struct Permissions {
     class: Class,
     attr: Option<Attribute>,
     pub(super) triad: PermissionsTriad,
@@ -42,7 +41,7 @@ pub enum PermissionsTriad {
 
 /// All `permissions_mask` arguments represents the bits of `st_mode` which excludes the file-type
 /// and the setuid, setgid, and sticky bit.
-impl ClassPermissions {
+impl Permissions {
     /// Computes user permissions.
     pub fn user_permissions_from(st_mode: u32) -> Self {
         let read = Self::enabled(st_mode, libc::S_IRUSR);
@@ -111,8 +110,8 @@ impl ClassPermissions {
     }
 }
 
-/// The symbolic representation of a [PermissionsTriad].
-impl Display for ClassPermissions {
+/// The symbolic representation of a [`PermissionsTriad`].
+impl Display for Permissions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.class {
             Class::Other if self.attr_is_sticky() => match self.triad {

--- a/src/fs/permissions/file_type.rs
+++ b/src/fs/permissions/file_type.rs
@@ -27,26 +27,26 @@ impl FileType {
     }
 }
 
-/// The argument `mode` is meant to come from the `mode` method of [std::fs::Permissions].
+/// The argument `mode` is meant to come from the `mode` method of [`std::fs::Permissions`].
 impl TryFrom<u32> for FileType {
     type Error = Error;
 
     fn try_from(mode: u32) -> Result<Self, Self::Error> {
-        let file_mask = mode & u32::from(libc::S_IFMT);
+        let file_mask = mode & libc::S_IFMT;
 
-        if file_mask == u32::from(libc::S_IFIFO) {
+        if file_mask == libc::S_IFIFO {
             Ok(Self::Fifo)
-        } else if file_mask == u32::from(libc::S_IFCHR) {
+        } else if file_mask == libc::S_IFCHR {
             Ok(Self::CharDevice)
-        } else if file_mask == u32::from(libc::S_IFDIR) {
+        } else if file_mask == libc::S_IFDIR {
             Ok(Self::Directory)
-        } else if file_mask == u32::from(libc::S_IFBLK) {
+        } else if file_mask == libc::S_IFBLK {
             Ok(Self::BlockDevice)
-        } else if file_mask == u32::from(libc::S_IFREG) {
+        } else if file_mask == libc::S_IFREG {
             Ok(Self::File)
-        } else if file_mask == u32::from(libc::S_IFLNK) {
+        } else if file_mask == libc::S_IFLNK {
             Ok(Self::Symlink)
-        } else if file_mask == u32::from(libc::S_IFSOCK) {
+        } else if file_mask == libc::S_IFSOCK {
             Ok(Self::Socket)
         } else {
             Err(Error::UnknownFileType)

--- a/src/fs/permissions/mod.rs
+++ b/src/fs/permissions/mod.rs
@@ -1,4 +1,3 @@
-use class::ClassPermissions;
 use error::Error;
 use file_type::FileType;
 use std::{
@@ -21,10 +20,10 @@ mod test;
 
 impl SymbolicNotation for std::fs::Permissions {}
 
-/// Trait that is used to extend [std::fs::Permissions] behavior such that it allows for `mode` to
+/// Trait that is used to extend [`std::fs::Permissions`] behavior such that it allows for `mode` to
 /// be expressed in Unix's symbolic notation for file permissions.
 pub trait SymbolicNotation: PermissionsExt {
-    /// Attempts to return a [FileMode] which implements [Display] allowing it to be presented in
+    /// Attempts to return a [`FileMode`] which implements [Display] allowing it to be presented in
     /// symbolic notation for file permissions.
     fn try_mode_symbolic_notation(&self) -> Result<FileMode, Error> {
         let mode = self.mode();
@@ -32,25 +31,25 @@ pub trait SymbolicNotation: PermissionsExt {
     }
 }
 
-/// A struct which holds information about the permissions of a particular file. [FileMode]
+/// A struct which holds information about the permissions of a particular file. [`FileMode`]
 /// implements [Display] which allows it to be conveniently presented in symbolic notation when
 /// expressing file permissions.
 pub struct FileMode {
     pub st_mode: u32,
     file_type: FileType,
-    user_permissions: ClassPermissions,
-    group_permissions: ClassPermissions,
-    other_permissions: ClassPermissions,
+    user_permissions: class::Permissions,
+    group_permissions: class::Permissions,
+    other_permissions: class::Permissions,
 }
 
 impl FileMode {
-    /// Constructor for [FileMode].
+    /// Constructor for [`FileMode`].
     pub const fn new(
         st_mode: u32,
         file_type: FileType,
-        user_permissions: ClassPermissions,
-        group_permissions: ClassPermissions,
-        other_permissions: ClassPermissions,
+        user_permissions: class::Permissions,
+        group_permissions: class::Permissions,
+        other_permissions: class::Permissions,
     ) -> Self {
         Self {
             st_mode,
@@ -66,23 +65,23 @@ impl FileMode {
         &self.file_type
     }
 
-    /// Returns a reference to a [ClassPermissions] which represents the permissions of the user class.
-    pub const fn user_permissions(&self) -> &ClassPermissions {
+    /// Returns a reference to a [`class::Permissions`] which represents the permissions of the user class.
+    pub const fn user_permissions(&self) -> &class::Permissions {
         &self.user_permissions
     }
 
-    /// Returns a reference to a [ClassPermissions] which represents the permissions of the group class.
-    pub const fn group_permissions(&self) -> &ClassPermissions {
+    /// Returns a reference to a [`class::Permissions`] which represents the permissions of the group class.
+    pub const fn group_permissions(&self) -> &class::Permissions {
         &self.group_permissions
     }
 
-    /// Returns a reference to a [ClassPermissions] which represents the permissions of the other class.
-    pub const fn other_permissions(&self) -> &ClassPermissions {
+    /// Returns a reference to a [`class::Permissions`] which represents the permissions of the other class.
+    pub const fn other_permissions(&self) -> &class::Permissions {
         &self.other_permissions
     }
 }
 
-/// For representing [FileMode] in symbolic notation.
+/// For representing [`FileMode`] in symbolic notation.
 impl Display for FileMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let file_iden = self.file_type().identifier();
@@ -100,20 +99,20 @@ impl Display for FileMode {
 /// For the octal representation of permissions
 impl Octal for FileMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let modes_mask = self.st_mode & !u32::from(libc::S_IFMT);
+        let modes_mask = self.st_mode & !libc::S_IFMT;
         fmt::Octal::fmt(&modes_mask, f)
     }
 }
 
-/// The argument `st_mode` is meant to come from the `mode` method of [std::fs::Permissions].
+/// The argument `st_mode` is meant to come from the `mode` method of [`std::fs::Permissions`].
 impl TryFrom<u32> for FileMode {
     type Error = Error;
 
     fn try_from(st_mode: u32) -> Result<Self, Self::Error> {
         let file_type = FileType::try_from(st_mode)?;
-        let user_permissions = ClassPermissions::user_permissions_from(st_mode);
-        let group_permissions = ClassPermissions::group_permissions_from(st_mode);
-        let other_permissions = ClassPermissions::other_permissions_from(st_mode);
+        let user_permissions = class::Permissions::user_permissions_from(st_mode);
+        let group_permissions = class::Permissions::group_permissions_from(st_mode);
+        let other_permissions = class::Permissions::other_permissions_from(st_mode);
 
         Ok(Self::new(
             st_mode,

--- a/src/fs/permissions/test.rs
+++ b/src/fs/permissions/test.rs
@@ -26,7 +26,7 @@ fn test_symbolic_notation() -> Result<(), Box<dyn Error>> {
     let rwx = format!("{file_mode}");
     assert_eq!(rwx, ".rw-r--r--");
 
-    let octal = format!("{:o}", file_mode);
+    let octal = format!("{file_mode:o}");
     assert_eq!(octal, "644");
 
     Ok(())
@@ -43,53 +43,53 @@ fn test_symbolic_notation_special_attr() -> Result<(), Box<dyn Error>> {
     let mut permissions = metadata.permissions();
 
     // Set the sticky bit
-    permissions.set_mode(0o101644);
+    permissions.set_mode(0o101_644);
 
     let file_mode = permissions.try_mode_symbolic_notation()?;
     let rwx = format!("{file_mode}");
     assert_eq!(rwx, ".rw-r--r-T");
 
-    let octal = format!("{:o}", file_mode);
+    let octal = format!("{file_mode:o}");
     assert_eq!(octal, "1644");
 
     // Set the getuid bit
-    permissions.set_mode(0o102644);
+    permissions.set_mode(0o102_644);
 
     let file_mode = permissions.try_mode_symbolic_notation()?;
     let rwx = format!("{file_mode}");
     assert_eq!(rwx, ".rw-r-Sr--");
 
-    let octal = format!("{:o}", file_mode);
+    let octal = format!("{file_mode:o}");
     assert_eq!(octal, "2644");
 
     // Set the setuid bit
-    permissions.set_mode(0o104644);
+    permissions.set_mode(0o104_644);
 
     let file_mode = permissions.try_mode_symbolic_notation()?;
     let rwx = format!("{file_mode}");
     assert_eq!(rwx, ".rwSr--r--");
 
-    let octal = format!("{:o}", file_mode);
+    let octal = format!("{file_mode:o}");
     assert_eq!(octal, "4644");
 
     // Set the all the attr bits
-    permissions.set_mode(0o107644);
+    permissions.set_mode(0o107_644);
 
     let file_mode = permissions.try_mode_symbolic_notation()?;
     let rwx = format!("{file_mode}");
     assert_eq!(rwx, ".rwSr-Sr-T");
 
-    let octal = format!("{:o}", file_mode);
+    let octal = format!("{file_mode:o}");
     assert_eq!(octal, "7644");
 
     // Set all the attr bits and give all classes execute permissions
-    permissions.set_mode(0o107777);
+    permissions.set_mode(0o107_777);
 
     let file_mode = permissions.try_mode_symbolic_notation()?;
     let rwx = format!("{file_mode}");
     assert_eq!(rwx, ".rwsrwsrwt");
 
-    let octal = format!("{:o}", file_mode);
+    let octal = format!("{file_mode:o}");
     assert_eq!(octal, "7777");
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,12 +12,8 @@
 #![allow(
     clippy::struct_excessive_bools,
     clippy::cast_precision_loss,
-    clippy::items_after_statements,
-    clippy::similar_names,
-    clippy::doc_markdown,
-    clippy::too_many_arguments,
-    clippy::type_complexity,
-    clippy::fallible_impl_from
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation
 )]
 use clap::CommandFactory;
 use render::{

--- a/src/render/context/file.rs
+++ b/src/render/context/file.rs
@@ -2,8 +2,7 @@ use clap::ValueEnum;
 
 /// File-types found in both Unix and Windows.
 #[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq, PartialOrd, Ord, Default)]
-#[allow(clippy::module_name_repetitions)]
-pub enum FileType {
+pub enum Type {
     /// A regular file.
     #[default]
     File,

--- a/src/render/context/sort.rs
+++ b/src/render/context/sort.rs
@@ -2,8 +2,7 @@ use clap::ValueEnum;
 
 /// Order in which to print nodes.
 #[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq, PartialOrd, Ord, Default)]
-#[allow(clippy::module_name_repetitions)]
-pub enum SortType {
+pub enum Type {
     /// Sort entries by file name
     Name,
 

--- a/src/render/context/test.rs
+++ b/src/render/context/test.rs
@@ -1,4 +1,4 @@
-use crate::render::context::sort::SortType;
+use crate::render::context::sort;
 use clap::{CommandFactory, FromArgMatches};
 
 use super::{config, Context};
@@ -17,7 +17,7 @@ fn config() {
 
     assert_eq!(
         sort,
-        SortType::Size,
+        sort::Type::Size,
         "Failed to properly read 'sort' from config"
     );
 

--- a/src/render/disk_usage/file_size.rs
+++ b/src/render/disk_usage/file_size.rs
@@ -40,7 +40,7 @@ pub enum DiskUsage {
 }
 
 impl FileSize {
-    /// Initializes a [FileSize].
+    /// Initializes a [`FileSize`].
     pub const fn new(
         bytes: u64,
         disk_usage: DiskUsage,
@@ -83,8 +83,6 @@ impl FileSize {
 
     /// Precompute the raw (unpadded) display and sets the number of columns the size (without
     /// the prefix) will occupy. Also sets the [Style] to use in advance to style the size output.
-    #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::cast_sign_loss)]
     pub fn precompute_unpadded_display(&mut self) {
         let fbytes = self.bytes as f64;
 
@@ -136,7 +134,7 @@ impl FileSize {
         }
     }
 
-    /// Formats [FileSize] for presentation.
+    /// Formats [`FileSize`] for presentation.
     pub fn format(&self, max_size_width: usize, max_size_unit_width: usize) -> String {
         let out = if self.human_readable {
             let mut precomputed = self.unpadded_display().unwrap().split(' ');
@@ -144,7 +142,10 @@ impl FileSize {
             let unit = precomputed.next().unwrap();
 
             if self.uses_base_unit.is_some() {
-                format!("{:>max_size_width$} {unit:>max_size_unit_width$}", self.bytes)
+                format!(
+                    "{:>max_size_width$} {unit:>max_size_unit_width$}",
+                    self.bytes
+                )
             } else {
                 format!("{size:>max_size_width$} {unit:>max_size_unit_width$}")
             }

--- a/src/render/styles/mod.rs
+++ b/src/render/styles/mod.rs
@@ -26,21 +26,21 @@ pub const UPRT: &str = "\u{2514}\u{2500} ";
 /// The `├─` box drawing characters.
 pub const VTRT: &str = "\u{251C}\u{2500} ";
 
-/// A runtime evaluated static. [LS_COLORS] the `LS_COLORS` environment variable to determine what
+/// A runtime evaluated static. [`LS_COLORS`] the `LS_COLORS` environment variable to determine what
 /// ANSI colors to use when printing the names of files. If `LS_COLORS` is not set it will fallback
 /// to a default defined in the `lscolors` crate.
 ///
-/// **Note for MacOS**: MacOS uses the `LSCOLORS` environment variable which is in a format not
+/// **Note for `MacOS`**: `MacOS` uses the `LSCOLORS` environment variable which is in a format not
 /// supported by the `lscolors` crate. Mac users can either set their own `LS_COLORS` environment
 /// variable to customize output color or rely on the default.
 static LS_COLORS: OnceCell<LsColors> = OnceCell::new();
 
 /// Runtime evaluated static that contains ANSI-colored box drawing characters used for the
-/// printing of [super::tree::Tree]'s branches.
+/// printing of [`super::tree::Tree`]'s branches.
 static TREE_THEME: OnceCell<ThemesMap> = OnceCell::new();
 
 /// Runtime evaluated static that contains ANSI-colored box drawing characters used for the
-/// printing of [super::tree::Tree]'s branches for descendents of symlinks.
+/// printing of [`super::tree::Tree`]'s branches for descendents of symlinks.
 static LINK_THEME: OnceCell<ThemesMap> = OnceCell::new();
 
 /// Runtime evaluated static that contains styles for disk usage output.
@@ -77,8 +77,8 @@ static BLOCK_STYLE: OnceCell<Style> = OnceCell::new();
 /// Map of the names box-drawing elements to their styled strings.
 pub type ThemesMap = HashMap<&'static str, String>;
 
-/// Initializes both [LS_COLORS] and all themes. If `plain` argument is `true` then plain colorless
-/// themes are used and [LS_COLORS] won't be initialized.
+/// Initializes both [`LS_COLORS`] and all themes. If `plain` argument is `true` then plain colorless
+/// themes are used and [`LS_COLORS`] won't be initialized.
 pub fn init(plain: bool) {
     #[cfg(windows)]
     let _ = ansi_term::enable_ansi_support();
@@ -91,31 +91,31 @@ pub fn init(plain: bool) {
     }
 }
 
-/// Getter for [LS_COLORS]. Returns an error if not initialized.
+/// Getter for [`LS_COLORS`]. Returns an error if not initialized.
 #[inline]
 pub fn get_ls_colors() -> Result<&'static LsColors, Error<'static>> {
     LS_COLORS.get().ok_or(Error::Uninitialized("LS_COLORS"))
 }
 
-/// Getter for [DU_THEME]. Returns an error if not initialized.
+/// Getter for [`DU_THEME`]. Returns an error if not initialized.
 #[inline]
 pub fn get_du_theme() -> Result<&'static HashMap<&'static str, Style>, Error<'static>> {
     DU_THEME.get().ok_or(Error::Uninitialized("DU_THEME"))
 }
 
-/// Getter for [TREE_THEME]. Returns an error if not initialized.
+/// Getter for [`TREE_THEME`]. Returns an error if not initialized.
 #[inline]
 pub fn get_tree_theme() -> Result<&'static ThemesMap, Error<'static>> {
     TREE_THEME.get().ok_or(Error::Uninitialized("TREE_THEME"))
 }
 
-/// Getter for [LINK_THEME]. Returns an error if not initialized.
+/// Getter for [`LINK_THEME`]. Returns an error if not initialized.
 #[inline]
 pub fn get_link_theme() -> Result<&'static ThemesMap, Error<'static>> {
     LINK_THEME.get().ok_or(Error::Uninitialized("LINK_THEME"))
 }
 
-/// Getter for [PERMISSIONS_THEME]. Returns an error if not initialized.
+/// Getter for [`PERMISSIONS_THEME`]. Returns an error if not initialized.
 #[cfg(unix)]
 #[inline]
 pub fn get_permissions_theme() -> Result<&'static HashMap<char, Style>, Error<'static>> {
@@ -124,7 +124,7 @@ pub fn get_permissions_theme() -> Result<&'static HashMap<char, Style>, Error<'s
         .ok_or(Error::Uninitialized("PERMISSIONS_THEME"))
 }
 
-/// Getter for [OCTAL_PERMISSIONS_STYLE]. Returns an error if not initialized.
+/// Getter for [`OCTAL_PERMISSIONS_STYLE`]. Returns an error if not initialized.
 #[cfg(unix)]
 #[inline]
 pub fn get_octal_permissions_style() -> Result<&'static Style, Error<'static>> {
@@ -133,7 +133,7 @@ pub fn get_octal_permissions_style() -> Result<&'static Style, Error<'static>> {
         .ok_or(Error::Uninitialized("OCTAL_PERMISSIONS_STYLE"))
 }
 
-/// Getter for [PLACEHOLDER_STYLE]. Returns an error if not initialized.
+/// Getter for [`PLACEHOLDER_STYLE`]. Returns an error if not initialized.
 #[inline]
 pub fn get_placeholder_style() -> Result<&'static Style, Error<'static>> {
     PLACEHOLDER_STYLE
@@ -141,28 +141,28 @@ pub fn get_placeholder_style() -> Result<&'static Style, Error<'static>> {
         .ok_or(Error::Uninitialized("PLACEHOLDER_STYLE"))
 }
 
-/// Getter for [INO_STYLE]. Returns an error if not initialized.
+/// Getter for [`INO_STYLE`]. Returns an error if not initialized.
 #[cfg(unix)]
 #[inline]
 pub fn get_ino_style() -> Result<&'static Style, Error<'static>> {
     INO_STYLE.get().ok_or(Error::Uninitialized("INO_STYLE"))
 }
 
-/// Getter for [NLINK_STYLE]. Returns an error if not initialized.
+/// Getter for [`NLINK_STYLE`]. Returns an error if not initialized.
 #[cfg(unix)]
 #[inline]
 pub fn get_nlink_style() -> Result<&'static Style, Error<'static>> {
     NLINK_STYLE.get().ok_or(Error::Uninitialized("NLINK_STYLE"))
 }
 
-/// Getter for [BLOCK_STYLE]. Returns an error if not initialized.
+/// Getter for [`BLOCK_STYLE`]. Returns an error if not initialized.
 #[cfg(unix)]
 #[inline]
 pub fn get_block_style() -> Result<&'static Style, Error<'static>> {
     BLOCK_STYLE.get().ok_or(Error::Uninitialized("BLOCK_STYLE"))
 }
 
-/// Getter for [DATETIME_STYLE]. Returns an error if not initialized.
+/// Getter for [`DATETIME_STYLE`]. Returns an error if not initialized.
 #[cfg(unix)]
 #[inline]
 pub fn get_datetime_style() -> Result<&'static Style, Error<'static>> {
@@ -171,7 +171,7 @@ pub fn get_datetime_style() -> Result<&'static Style, Error<'static>> {
         .ok_or(Error::Uninitialized("DATETIME_STYLE"))
 }
 
-/// Initializes [LS_COLORS] by reading in the `LS_COLORS` environment variable. If it isn't set, a
+/// Initializes [`LS_COLORS`] by reading in the `LS_COLORS` environment variable. If it isn't set, a
 /// default determined by `lscolors` crate will be used.
 fn init_ls_colors() {
     LS_COLORS

--- a/src/render/tree/mod.rs
+++ b/src/render/tree/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     fs::inode::Inode,
     render::{
-        context::{file::FileType, output::ColumnProperties, Context},
+        context::{file, output::ColumnProperties, Context},
         disk_usage::file_size::FileSize,
         styles,
     },
@@ -90,7 +90,7 @@ where
         Ok(tree)
     }
 
-    /// Returns `true` if there are no entries to show excluding the root_id.
+    /// Returns `true` if there are no entries to show excluding the `root_id`.
     pub fn is_stump(&self) -> bool {
         self.root_id
             .descendants(self.arena())
@@ -115,7 +115,7 @@ where
         &self.arena
     }
 
-    /// Parallel traversal of the root_id directory and its contents. Parallel traversal relies on
+    /// Parallel traversal of the `root_id` directory and its contents. Parallel traversal relies on
     /// `WalkParallel`. Any filesystem I/O or related system calls are expected to occur during
     /// parallel traversal; post-processing post-processing of all directory entries should
     /// be completely CPU-bound.
@@ -173,7 +173,7 @@ where
                     ctx,
                 );
 
-                if ctx.prune || ctx.file_type != Some(FileType::Dir) {
+                if ctx.prune || ctx.file_type != Some(file::Type::Dir) {
                     Self::prune_directories(root_id, &mut tree);
                 }
 
@@ -335,7 +335,7 @@ where
         count
     }
 
-    /// Updates [ColumnProperties] with provided [Node].
+    /// Updates [`ColumnProperties`] with provided [Node].
     #[cfg(unix)]
     fn update_column_properties(col_props: &mut ColumnProperties, node: &Node, long: bool) {
         if let Some(file_size) = node.file_size() {

--- a/src/render/tree/node/cmp.rs
+++ b/src/render/tree/node/cmp.rs
@@ -1,5 +1,5 @@
 use super::Node;
-use crate::render::context::{sort::SortType, Context};
+use crate::render::context::{sort, Context};
 use std::cmp::Ordering;
 
 /// Comparator type used to sort [Node]s.
@@ -17,11 +17,11 @@ pub fn comparator(ctx: &Context) -> Box<NodeComparator> {
 }
 
 /// Grabs the comparator for two non-dir type [Node]s.
-fn base_comparator(sort_type: SortType) -> Box<NodeComparator> {
+fn base_comparator(sort_type: sort::Type) -> Box<NodeComparator> {
     match sort_type {
-        SortType::Name => Box::new(name_comparator),
-        SortType::Size => Box::new(size_comparator),
-        SortType::SizeRev => Box::new(size_rev_comparator),
+        sort::Type::Name => Box::new(name_comparator),
+        sort::Type::Size => Box::new(size_comparator),
+        sort::Type::SizeRev => Box::new(size_rev_comparator),
     }
 }
 

--- a/src/render/tree/node/display/mod.rs
+++ b/src/render/tree/node/display/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ansi::AnsiEscaped,
+    ansi::Escaped,
     render::{context::Context, tree::node::Node},
 };
 use std::{
@@ -45,7 +45,7 @@ impl Node {
 
         if ctx.truncate && ctx.window_width.is_some() {
             let window_width = ctx.window_width.unwrap();
-            let out = <str as AnsiEscaped>::truncate(&ln, window_width);
+            let out = <str as Escaped>::truncate(&ln, window_width);
             write!(f, "{out}")
         } else {
             write!(f, "{ln}")
@@ -94,7 +94,7 @@ impl Node {
 
         if ctx.truncate && ctx.window_width.is_some() {
             let window_width = ctx.window_width.unwrap();
-            let out = <str as AnsiEscaped>::truncate(&ln, window_width);
+            let out = <str as Escaped>::truncate(&ln, window_width);
             writeln!(f, "{out}")
         } else {
             writeln!(f, "{ln}")

--- a/src/render/tree/node/display/presenters.rs
+++ b/src/render/tree/node/display/presenters.rs
@@ -27,14 +27,14 @@ pub(super) struct LongAttrs {
 #[cfg(unix)]
 #[inline]
 pub(super) fn format_long(node: &Node, ctx: &Context) -> LongAttrs {
-    let mode = node.mode().unwrap();
+    let file_mode = node.mode().unwrap();
 
     let perms = if ctx.octal {
-        Node::style_octal_permissions(&mode)
+        Node::style_octal_permissions(&file_mode)
     } else if node.has_xattrs() {
-        Node::style_sym_permissions(&mode, true)
+        Node::style_sym_permissions(&file_mode, true)
     } else {
-        Node::style_sym_permissions(&mode, false)
+        Node::style_sym_permissions(&file_mode, false)
     };
 
     let datetime = match ctx.time() {

--- a/src/render/tree/node/mod.rs
+++ b/src/render/tree/node/mod.rs
@@ -36,7 +36,7 @@ pub mod display;
 /// Styling utilities for a [Node].
 pub mod style;
 
-/// A node of [`Tree`] that can be created from a [DirEntry]. Any filesystem I/O and
+/// A node of [`Tree`] that can be created from a [`DirEntry`]. Any filesystem I/O and
 /// relevant system calls are expected to complete after initialization. A `Node` when `Display`ed
 /// uses ANSI colors determined by the file-type and `LS_COLORS`.
 ///
@@ -92,7 +92,7 @@ impl Node {
         self.dir_entry.depth()
     }
 
-    /// Gets the number of blocks used by the underlying [DirEntry]. Returns `None` in the case of
+    /// Gets the number of blocks used by the underlying [`DirEntry`]. Returns `None` in the case of
     /// no blocks allocated like in the case of directories.
     #[cfg(unix)]
     pub fn blocks(&self) -> Option<u64> {
@@ -127,12 +127,12 @@ impl Node {
         self.inode
     }
 
-    /// Returns the underlying `ino` of the [DirEntry].
+    /// Returns the underlying `ino` of the [`DirEntry`].
     pub fn ino(&self) -> Option<u64> {
         self.inode.map(|inode| inode.ino)
     }
 
-    /// Returns the underlying `nlink` of the [DirEntry].
+    /// Returns the underlying `nlink` of the [`DirEntry`].
     pub fn nlink(&self) -> Option<u64> {
         self.inode.map(|inode| inode.nlink)
     }
@@ -157,7 +157,7 @@ impl Node {
         self.symlink_target_path().and_then(Path::file_name)
     }
 
-    /// Returns reference to underlying [FileType].
+    /// Returns reference to underlying [`FileType`].
     pub fn file_type(&self) -> Option<FileType> {
         self.dir_entry.file_type()
     }
@@ -167,13 +167,13 @@ impl Node {
         self.path().parent()
     }
 
-    /// Returns a reference to `path`. If the underlying [DirEntry] is a symlink then the path of
+    /// Returns a reference to `path`. If the underlying [`DirEntry`] is a symlink then the path of
     /// the symlink shall be returned.
     pub fn path(&self) -> &Path {
         self.dir_entry.path()
     }
 
-    /// Gets 'file_size'.
+    /// Gets '`file_size`'.
     pub const fn file_size(&self) -> Option<&FileSize> {
         self.file_size.as_ref()
     }
@@ -183,7 +183,7 @@ impl Node {
         self.file_size = Some(size);
     }
 
-    /// Attempts to return an instance of [FileMode] for the display of symbolic permissions.
+    /// Attempts to return an instance of [`FileMode`] for the display of symbolic permissions.
     #[cfg(unix)]
     pub fn mode(&self) -> Result<FileMode, Error> {
         let permissions = self.metadata.permissions();
@@ -209,7 +209,7 @@ impl Node {
         self.flat(f, ctx)
     }
 
-    /// See [icons::compute].
+    /// See [`icons::compute`].
     fn compute_icon(&self, no_color: bool) -> Cow<'static, str> {
         if no_color {
             icons::compute(self.dir_entry(), self.symlink_target_path())

--- a/tests/hardlink.rs
+++ b/tests/hardlink.rs
@@ -17,7 +17,7 @@ fn hardlink() -> Result<(), Box<dyn Error>> {
         .join("hardlinks")
         .join("curwin.hpl");
 
-    fs::hard_link(&src, &link)?;
+    fs::hard_link(src, &link)?;
 
     let out = utils::run_cmd(&["tests/hardlinks"]);
 


### PR DESCRIPTION
This commit is trying to get rid of the silenced Clippy warnings and fix them. The three Clippy lints “cast_precision_loss”, “cast_sign_loss” and “cast_possible_truncation” are not really fixable and just in the way, which is why they are now muted in the whole project. The “struct_excessive_bool” lint has not been fixed, as it would probably require a breaking change.
I will start an issue, discussing this.