### PR TITLE
Added Windows specific config location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+dependencies = [
+ "libc",
+ "redox_users",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "erdtree"
 version = "2.0.0"
 dependencies = [
@@ -204,6 +224,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "dirs",
  "filesize",
  "ignore",
  "indextree",
@@ -274,6 +295,17 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "getrandom"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
 
 [[package]]
 name = "globset"
@@ -551,6 +583,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -776,6 +819,12 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ ansi_term = "0.12.1"
 chrono = "0.4.24"
 clap = { version = "4.1.1", features = ["derive"] }
 clap_complete = "4.1.1"
+dirs = "5.0"
 filesize = "0.2.0"
 ignore = "0.4.2"
 indextree = "4.6.0"

--- a/README.md
+++ b/README.md
@@ -168,8 +168,9 @@ If `erdtree`'s out-of-the-box defaults don't meet your specific requirements, yo
 - `$ERDTREE_CONFIG_PATH`
 - `$XDG_CONFIG_HOME/erdtree/.erdtreerc`
 - `$XDG_CONFIG_HOME/.erdtreerc`
-- `$HOME/.config/erdtree/.erdtreerc`
-- `$HOME/.erdtreerc`
+- `$HOME/.config/erdtree/.erdtreerc` (on non-Windows)
+- `$HOME/.erdtreerc` (on non-Windows)
+- `%APPDATA%/erdtree/.erdtreerc` (on Windows only)
 
 The format of a config file is as follows:
 - Every line is an `erdtree` option/argument.

--- a/README.md
+++ b/README.md
@@ -165,12 +165,17 @@ Other means of installation to come.
 If `erdtree`'s out-of-the-box defaults don't meet your specific requirements, you can set your own defaults using a configuration file.
 
 `erdtree` will look for a configuration file in any of these locations:
+
+On Linux/Mac/Unix-like:
 - `$ERDTREE_CONFIG_PATH`
 - `$XDG_CONFIG_HOME/erdtree/.erdtreerc`
 - `$XDG_CONFIG_HOME/.erdtreerc`
-- `$HOME/.config/erdtree/.erdtreerc` (on non-Windows)
-- `$HOME/.erdtreerc` (on non-Windows)
-- `%APPDATA%/erdtree/.erdtreerc` (on Windows only)
+- `$HOME/.config/erdtree/.erdtreerc`
+- `$HOME/.erdtreerc`
+
+On Windows:
+- `$ERDTREE_CONFIG_PATH`
+- `%APPDATA%/erdtree/.erdtreerc`
 
 The format of a config file is as follows:
 - Every line is an `erdtree` option/argument.

--- a/src/render/context/config.rs
+++ b/src/render/context/config.rs
@@ -55,6 +55,7 @@ fn config_from_config_path() -> Option<String> {
 /// Try to read in config from either one of the following locations:
 /// - `$HOME/.config/erdtree/.erdtreerc`
 /// - `$HOME/.erdtreerc`
+#[cfg(not(windows))]
 fn config_from_home() -> Option<String> {
     let home = env::var_os(HOME).map(PathBuf::from)?;
 
@@ -67,6 +68,19 @@ fn config_from_home() -> Option<String> {
         let config_path = home.join(ERDTREE_CONFIG_NAME);
         fs::read_to_string(config_path).ok()
     })
+}
+
+/// Windows specific: Try to read in config from the following location:
+/// - `%APPDATA%/erdtree/.erdtreerc`
+#[cfg(windows)]
+fn config_from_home() -> Option<String> {
+    let app_data = dirs::config_dir()?;
+
+    let config_path = app_data
+        .join(ERDTREE_DIR)
+        .join(ERDTREE_CONFIG_NAME);
+
+    fs::read_to_string(config_path).ok()
 }
 
 /// Try to read in config from either one of the following locations:

--- a/src/render/tree/node/display/mod.rs
+++ b/src/render/tree/node/display/mod.rs
@@ -119,7 +119,7 @@ impl Node {
 
         if ctx.truncate && ctx.window_width.is_some() {
             let window_width = ctx.window_width.unwrap();
-            let out = <str as AnsiEscaped>::truncate(&ln, window_width);
+            let out = <str as Escaped>::truncate(&ln, window_width);
             writeln!(f, "{out}")
         } else {
             writeln!(f, "{ln}")
@@ -143,7 +143,7 @@ impl Node {
 
         if ctx.truncate && ctx.window_width.is_some() {
             let window_width = ctx.window_width.unwrap();
-            let out = <str as AnsiEscaped>::truncate(&ln, window_width);
+            let out = <str as Escaped>::truncate(&ln, window_width);
             write!(f, "{out}")
         } else {
             write!(f, "{ln}")


### PR DESCRIPTION
Windows by default does not set or use the $HOME environment variable. This commit adds a Windows specific branch which tries to locate the config file in %APPDATA%/erdtree/.erdtreerc instead

Fixes #152 