### PR TITLE
extra granularity for dir ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@ All notable changes to this project will be documented in this file.
  
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.1] - 2023-04-29
+
+## What's Changed
+
+`erdtree` v2.0.0 introduces numerous breaking changes as well as a plethora of new features. Most breaking changes are predicated on the fact that
+arguments were either renamed, removed, or fundamentally modified. The following is a list of all the PRs that document these changes and feature additions:
+
+- https://github.com/solidiquis/erdtree/pull/130
+- https://github.com/solidiquis/erdtree/pull/132
+- https://github.com/solidiquis/erdtree/pull/135
+- https://github.com/solidiquis/erdtree/pull/136
+- https://github.com/solidiquis/erdtree/pull/137
+- https://github.com/solidiquis/erdtree/pull/138
+- https://github.com/solidiquis/erdtree/pull/139
+- https://github.com/solidiquis/erdtree/pull/131
+
+Perhaps the most important change to note is that the compiled binary has been renamed from `et` to `erd` in order to address the following issue
+regarding name collisions with other programs: https://github.com/solidiquis/erdtree/issues/23
+
+For a more comprehensive overview of `erdtree` v2.0.0, please refer to the [README.md](README.md).
+
+**Full Changelog**: https://github.com/solidiquis/erdtree/compare/v2.0.0...v2.0.1
+
 ## [2.0.0] - 2023-04-26
 
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,29 +3,6 @@ All notable changes to this project will be documented in this file.
  
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.0.1] - 2023-04-29
-
-## What's Changed
-
-`erdtree` v2.0.0 introduces numerous breaking changes as well as a plethora of new features. Most breaking changes are predicated on the fact that
-arguments were either renamed, removed, or fundamentally modified. The following is a list of all the PRs that document these changes and feature additions:
-
-- https://github.com/solidiquis/erdtree/pull/130
-- https://github.com/solidiquis/erdtree/pull/132
-- https://github.com/solidiquis/erdtree/pull/135
-- https://github.com/solidiquis/erdtree/pull/136
-- https://github.com/solidiquis/erdtree/pull/137
-- https://github.com/solidiquis/erdtree/pull/138
-- https://github.com/solidiquis/erdtree/pull/139
-- https://github.com/solidiquis/erdtree/pull/131
-
-Perhaps the most important change to note is that the compiled binary has been renamed from `et` to `erd` in order to address the following issue
-regarding name collisions with other programs: https://github.com/solidiquis/erdtree/issues/23
-
-For a more comprehensive overview of `erdtree` v2.0.0, please refer to the [README.md](README.md).
-
-**Full Changelog**: https://github.com/solidiquis/erdtree/compare/v2.0.0...v2.0.1
-
 ## [2.0.0] - 2023-04-26
 
 ## What's Changed

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Arguments:
   [DIR]  Directory to traverse; defaults to current working directory
 
 Options:
-  -C, --color                      Output Coloring [default: auto] [possible values: none, auto, forced]
+  -C, --color <COLOR>              Mode of coloring output [default: auto] [possible values: none, auto, forced]
   -d, --disk-usage <DISK_USAGE>    Print physical or logical file size [default: physical] [possible values: logical, physical]
   -f, --follow                     Follow symlinks
   -F, --flat                       Print disk usage information in plain format without the ASCII tree
@@ -79,7 +79,7 @@ Options:
   -t, --file-type <FILE_TYPE>      Restrict regex or glob search to a particular file-type [possible values: file, dir, link]
   -P, --prune                      Remove empty directories from output
   -s, --sort <SORT>                Sort-order to display directory content [default: size] [possible values: name, size, size-rev]
-      --dirs-first                 Sort directories above files
+      --dir-order <DIR_ORDER>      Sort directories before or after all other file types [default: none] [possible values: none, first, last]
   -T, --threads <THREADS>          Number of threads to use [default: 3]
   -u, --unit <UNIT>                Report disk usage in binary or SI units [default: bin] [possible values: bin, si]
   -., --hidden                     Show hidden files

--- a/README.md
+++ b/README.md
@@ -341,13 +341,21 @@ Various sorting methods are provided:
 
 ```
 -s, --sort <SORT>                Sort-order to display directory content [default: size] [possible values: name, size, size-rev]
-    --dirs-first                 Sort directories above files
+    --dir-order <DIR_ORDER>      Sort directories before or after all other file types [default: none] [possible values: none, first, last]
 ```
 
-To ensure that directories appear before all other file-types:
+To add extra granularity to how directories are sorted relative to other file-types, use `--dir-order`:
 
 ```
---dirs-first                 Sort directories above files
+--dir-order <DIR_ORDER>
+    Sort directories before or after all other file types
+    
+    [default: none]
+
+    Possible values:
+    - none:  Directories are ordered as if they were regular nodes
+    - first: Sort directories above files
+    - last:  Sort directories below files
 ```
 
 ### Directories only

--- a/src/fs/permissions/file_type.rs
+++ b/src/fs/permissions/file_type.rs
@@ -27,7 +27,7 @@ impl FileType {
     }
 }
 
-/// The argument `mode` is meant to come from the `mode` method of [std::fs::Permissions].
+/// The argument `mode` is meant to come from the `mode` method of [`std::fs::Permissions`].
 impl TryFrom<u32> for FileType {
     type Error = Error;
 

--- a/src/render/context/color.rs
+++ b/src/render/context/color.rs
@@ -1,0 +1,15 @@
+use clap::ValueEnum;
+
+/// Enum to determine how the output should be colorized.
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq, Default)]
+pub enum Coloring {
+    /// Print plainly without ANSI escapes
+    None,
+
+    /// Attempt to colorize output
+    #[default]
+    Auto,
+
+    /// Turn on colorization always
+    Forced,
+}

--- a/src/render/context/dir.rs
+++ b/src/render/context/dir.rs
@@ -1,0 +1,15 @@
+use clap::ValueEnum;
+
+/// Enum to determine how directories should be ordered relative to regular files in output.
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq, Default)]
+pub enum Order {
+    /// Directories are ordered as if they were regular nodes.
+    #[default]
+    None,
+
+    /// Sort directories above files
+    First,
+
+    /// Sort directories below files
+    Last
+}

--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -126,7 +126,7 @@ pub struct Context {
     #[arg(short, long, value_enum, default_value_t = sort::Type::default())]
     pub sort: sort::Type,
 
-    /// Sort directories above files
+    /// Sort directories before or after all other file types
     #[arg(long, value_enum, default_value_t = dir::Order::default())]
     pub dir_order: dir::Order,
 

--- a/src/render/context/mod.rs
+++ b/src/render/context/mod.rs
@@ -1,6 +1,7 @@
 use super::disk_usage::{file_size::DiskUsage, units::PrefixKind};
 use crate::tty;
 use clap::{parser::ValueSource, ArgMatches, CommandFactory, FromArgMatches, Id, Parser};
+use color::Coloring;
 use error::Error;
 use ignore::{
     overrides::{Override, OverrideBuilder},
@@ -17,6 +18,12 @@ use std::{
 
 /// Operations to load in defaults from configuration file.
 pub mod config;
+
+/// Controlling color of output.
+pub mod color;
+
+/// Controlling order of directories in output.
+pub mod dir;
 
 /// [Context] related errors.
 pub mod error;
@@ -38,20 +45,6 @@ pub mod time;
 #[cfg(test)]
 mod test;
 
-#[derive(Clone, Copy, Debug, clap::ValueEnum, PartialEq, Eq, Default)]
-pub enum Coloring {
-    /// Print plainly without ANSI escapes
-    None,
-
-    /// Check the [`no_color`] function for the Auto behaviour
-    ///
-    /// [`no_color`]: no_color
-    #[default]
-    Auto,
-
-    /// Turn on colorization always
-    Forced,
-}
 /// Defines the CLI.
 #[derive(Parser, Debug)]
 #[command(name = "erdtree")]
@@ -62,7 +55,7 @@ pub struct Context {
     /// Directory to traverse; defaults to current working directory
     dir: Option<PathBuf>,
 
-    /// Coloring of the Output
+    /// Mode of coloring output
     #[arg(short = 'C', long, value_enum, default_value_t = Coloring::default())]
     pub color: Coloring,
 
@@ -134,8 +127,8 @@ pub struct Context {
     pub sort: sort::Type,
 
     /// Sort directories above files
-    #[arg(long)]
-    pub dirs_first: bool,
+    #[arg(long, value_enum, default_value_t = dir::Order::default())]
+    pub dir_order: dir::Order,
 
     /// Number of threads to use
     #[arg(short = 'T', long, default_value_t = 3)]
@@ -216,6 +209,7 @@ pub struct Context {
     pub window_width: Option<usize>,
 }
 type Predicate = Result<Box<dyn Fn(&DirEntry) -> bool + Send + Sync + 'static>, Error>;
+
 impl Context {
     /// Initializes [Context], optionally reading in the configuration file to override defaults.
     /// Arguments provided will take precedence over config.

--- a/src/render/tree/node/cmp.rs
+++ b/src/render/tree/node/cmp.rs
@@ -1,5 +1,5 @@
 use super::Node;
-use crate::render::context::{sort, Context};
+use crate::render::context::{dir, sort, Context};
 use std::cmp::Ordering;
 
 /// Comparator type used to sort [Node]s.
@@ -9,9 +9,15 @@ pub type NodeComparator = dyn Fn(&Node, &Node) -> Ordering;
 pub fn comparator(ctx: &Context) -> Box<NodeComparator> {
     let sort_type = ctx.sort;
 
-    if ctx.dirs_first {
-        return Box::new(move |a, b| dir_comparator(a, b, base_comparator(sort_type)));
-    }
+    match ctx.dir_order {
+        dir::Order::None => (),
+        dir::Order::First => {
+            return Box::new(move |a, b| dir_first_comparator(a, b, base_comparator(sort_type)));
+        },
+        dir::Order::Last => {
+            return Box::new(move |a, b| dir_last_comparator(a, b, base_comparator(sort_type)));
+        },
+    };
 
     base_comparator(sort_type)
 }
@@ -26,7 +32,16 @@ fn base_comparator(sort_type: sort::Type) -> Box<NodeComparator> {
 }
 
 /// Orders directories first. Provides a fallback if inputs are not directories.
-fn dir_comparator(a: &Node, b: &Node, fallback: impl Fn(&Node, &Node) -> Ordering) -> Ordering {
+fn dir_first_comparator(a: &Node, b: &Node, fallback: impl Fn(&Node, &Node) -> Ordering) -> Ordering {
+    match (a.is_dir(), b.is_dir()) {
+        (true, false) => Ordering::Greater,
+        (false, true) => Ordering::Less,
+        _ => fallback(a, b),
+    }
+}
+
+/// Orders directories last. Provides a fallback if inputs are not directories.
+fn dir_last_comparator(a: &Node, b: &Node, fallback: impl Fn(&Node, &Node) -> Ordering) -> Ordering {
     match (a.is_dir(), b.is_dir()) {
         (true, false) => Ordering::Less,
         (false, true) => Ordering::Greater,

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -25,11 +25,29 @@ fn sort_name() {
 }
 
 #[test]
-fn sort_name_dir_first() {
+fn sort_name_dir_order() {
     assert_eq!(
-        utils::run_cmd(&["--sort", "name", "--dirs-first", "tests/data"]),
+        utils::run_cmd(&["--sort", "name", "--dir-order", "first", "tests/data"]),
         indoc!(
-            "100  B ┌─ nylarlathotep.txt
+           "143  B    ┌─ cassildas_song.md
+            143  B ┌─ the_yellow_king
+            446  B │  ┌─ lipsum.txt
+            446  B ├─ lipsum
+            308  B │  ┌─ polaris.txt
+            308  B ├─ dream_cycle
+            100  B ├─ nylarlathotep.txt
+            161  B ├─ nemesis.txt
+            83   B ├─ necronomicon.txt
+            1241 B data
+
+            3 directories, 6 files"
+        )
+    );
+
+    assert_eq!(
+        utils::run_cmd(&["--sort", "name", "--dir-order", "last", "tests/data"]),
+        indoc!(
+           "100  B ┌─ nylarlathotep.txt
             161  B ├─ nemesis.txt
             83   B ├─ necronomicon.txt
             143  B │  ┌─ cassildas_song.md
@@ -41,9 +59,8 @@ fn sort_name_dir_first() {
             1241 B data
 
             3 directories, 6 files"
-        ),
-        "Failed to sort by directory and alphabetically by file name"
-    )
+        )
+    );
 }
 
 #[test]
@@ -65,27 +82,5 @@ fn sort_size() {
             3 directories, 6 files"
         ),
         "Failed to sort by descending size"
-    )
-}
-
-#[test]
-fn sort_size_dir_first() {
-    assert_eq!(
-        utils::run_cmd(&["--sort", "size-rev", "--dirs-first", "tests/data"]),
-        indoc!(
-            "161  B ┌─ nemesis.txt
-            100  B ├─ nylarlathotep.txt
-            83   B ├─ necronomicon.txt
-            446  B │  ┌─ lipsum.txt
-            446  B ├─ lipsum
-            308  B │  ┌─ polaris.txt
-            308  B ├─ dream_cycle
-            143  B │  ┌─ cassildas_song.md
-            143  B ├─ the_yellow_king
-            1241 B data
-
-            3 directories, 6 files"
-        ),
-        "Failed to sort by directory and descending size"
     )
 }


### PR DESCRIPTION
Closes https://github.com/solidiquis/erdtree/issues/149

### Additions

```
--dir-order <DIR_ORDER>      Sort directories before or after all other file types [default: none] [possible values: none, first, last]
```

```
--dir-order <DIR_ORDER>
    Sort directories before or after all other file types
    
    [default: none]

    Possible values:
    - none:  Directories are ordered as if they were regular nodes
    - first: Sort directories above files
    - last:  Sort directories below files

```