### PR TITLE
show symlink target's path, not just name

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,9 @@ If multiple hardlinks that point to the same inode are in the same file-tree, al
 -f, --follow                     Follow symlinks
 ```
 
-Symlinks will never be counted towards the total disk usage. When a symlink to a directory is followed all of the box-drawing characters of its descendants will
-be painted in a different color for better visual feedback:
+Symlinks when followed will have their targets (and descendants) counted towards total disk usage, otherwise the size of the symlink itself will be reported.
+If a symlink's target happens to be in the same file-tree as the symlink itself, the target and its descendants will not be double-counted towards the total disk-usage.
+When a symlink to a directory is followed all of the box-drawing characters of its descendants will be painted in a different color for better visual feedback:
 
 <p align="center">
   <img src="https://github.com/solidiquis/erdtree/blob/master/assets/symlinks.png?raw=true" alt="failed to load picture" />

--- a/src/render/context/config.rs
+++ b/src/render/context/config.rs
@@ -91,9 +91,7 @@ fn config_from_home() -> Option<String> {
 fn config_from_appdata() -> Option<String> {
     let app_data = dirs::config_dir()?;
 
-    let config_path = app_data
-        .join(ERDTREE_DIR)
-        .join(ERDTREE_CONFIG_NAME);
+    let config_path = app_data.join(ERDTREE_DIR).join(ERDTREE_CONFIG_NAME);
 
     fs::read_to_string(config_path).ok()
 }

--- a/src/render/context/dir.rs
+++ b/src/render/context/dir.rs
@@ -11,5 +11,5 @@ pub enum Order {
     First,
 
     /// Sort directories below files
-    Last
+    Last,
 }

--- a/src/render/tree/node/cmp.rs
+++ b/src/render/tree/node/cmp.rs
@@ -13,10 +13,10 @@ pub fn comparator(ctx: &Context) -> Box<NodeComparator> {
         dir::Order::None => (),
         dir::Order::First => {
             return Box::new(move |a, b| dir_first_comparator(a, b, base_comparator(sort_type)));
-        },
+        }
         dir::Order::Last => {
             return Box::new(move |a, b| dir_last_comparator(a, b, base_comparator(sort_type)));
-        },
+        }
     };
 
     base_comparator(sort_type)
@@ -32,7 +32,11 @@ fn base_comparator(sort_type: sort::Type) -> Box<NodeComparator> {
 }
 
 /// Orders directories first. Provides a fallback if inputs are not directories.
-fn dir_first_comparator(a: &Node, b: &Node, fallback: impl Fn(&Node, &Node) -> Ordering) -> Ordering {
+fn dir_first_comparator(
+    a: &Node,
+    b: &Node,
+    fallback: impl Fn(&Node, &Node) -> Ordering,
+) -> Ordering {
     match (a.is_dir(), b.is_dir()) {
         (true, false) => Ordering::Greater,
         (false, true) => Ordering::Less,
@@ -41,7 +45,11 @@ fn dir_first_comparator(a: &Node, b: &Node, fallback: impl Fn(&Node, &Node) -> O
 }
 
 /// Orders directories last. Provides a fallback if inputs are not directories.
-fn dir_last_comparator(a: &Node, b: &Node, fallback: impl Fn(&Node, &Node) -> Ordering) -> Ordering {
+fn dir_last_comparator(
+    a: &Node,
+    b: &Node,
+    fallback: impl Fn(&Node, &Node) -> Ordering,
+) -> Ordering {
     match (a.is_dir(), b.is_dir()) {
         (true, false) => Ordering::Less,
         (false, true) => Ordering::Greater,

--- a/src/render/tree/node/mod.rs
+++ b/src/render/tree/node/mod.rs
@@ -154,7 +154,7 @@ impl Node {
 
     /// Returns the file name of the symlink target if [Node] represents a symlink.
     pub fn symlink_target_file_name(&self) -> Option<&OsStr> {
-        self.symlink_target_path().and_then(Path::file_name)
+        self.symlink_target_path().map(Path::as_os_str)
     }
 
     /// Returns reference to underlying [`FileType`].

--- a/src/render/tree/node/mod.rs
+++ b/src/render/tree/node/mod.rs
@@ -241,10 +241,20 @@ impl TryFrom<(DirEntry, &Context)> for Node {
         let file_type = dir_entry.file_type();
 
         let mut file_size = match file_type {
-            Some(ref ft) if ft.is_file() && !ctx.suppress_size => match ctx.disk_usage {
-                DiskUsage::Logical => Some(FileSize::logical(&metadata, ctx.unit, ctx.human)),
-                DiskUsage::Physical => FileSize::physical(path, &metadata, ctx.unit, ctx.human),
-            },
+            Some(ref ft) if !ctx.suppress_size => {
+                if ft.is_file() || (ft.is_symlink() && !ctx.follow) {
+                    match ctx.disk_usage {
+                        DiskUsage::Logical => {
+                            Some(FileSize::logical(&metadata, ctx.unit, ctx.human))
+                        }
+                        DiskUsage::Physical => {
+                            FileSize::physical(path, &metadata, ctx.unit, ctx.human)
+                        }
+                    }
+                } else {
+                    None
+                }
+            }
             _ => None,
         };
 

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -29,7 +29,7 @@ fn sort_name_dir_order() {
     assert_eq!(
         utils::run_cmd(&["--sort", "name", "--dir-order", "first", "tests/data"]),
         indoc!(
-           "143  B    ┌─ cassildas_song.md
+            "143  B    ┌─ cassildas_song.md
             143  B ┌─ the_yellow_king
             446  B │  ┌─ lipsum.txt
             446  B ├─ lipsum
@@ -47,7 +47,7 @@ fn sort_name_dir_order() {
     assert_eq!(
         utils::run_cmd(&["--sort", "name", "--dir-order", "last", "tests/data"]),
         indoc!(
-           "100  B ┌─ nylarlathotep.txt
+            "100  B ┌─ nylarlathotep.txt
             161  B ├─ nemesis.txt
             83   B ├─ necronomicon.txt
             143  B │  ┌─ cassildas_song.md


### PR DESCRIPTION
Closes https://github.com/solidiquis/erdtree/issues/148

<img width="716" alt="Screen Shot 2023-04-30 at 11 24 21 PM" src="https://user-images.githubusercontent.com/45523555/235416366-393c9777-c72d-45ee-8dac-1900ec9a1383.png">
