### PR TITLE
add support for specifying time formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Options:
   -l, --long                       Show extended metadata and attributes
       --octal                      Show permissions in numeric octal format instead of symbolic
       --time <TIME>                Which kind of timestamp to use; modified by default [possible values: created, accessed, modified]
+      --time-format                Which format to use for the timestamp; default by default [possible values: iso, iso-strict, short, default]
   -L, --level <NUM>                Maximum depth to display
   -p, --pattern <PATTERN>          Regular expression (or glob if '--glob' or '--iglob' is used) used to match files
       --glob                       Enables glob based searching
@@ -100,6 +101,7 @@ Of all the above arguments, the following are not yet available on Windows but w
   -l, --long                       Show extended metadata and attributes
       --octal                      Show permissions in numeric octal format instead of symbolic
       --time <TIME>                Which kind of timestamp to use; modified by default [possible values: created, accessed, modified]
+      --time-format                Which format to use for the timestamp; default by default [possible values: iso, iso-strict, short, default]
 ```
 
 ## Installation
@@ -377,6 +379,7 @@ Unix file permissions as well as metadata associated with directory entries can 
 -l, --long                       Show extended metadata and attributes
     --octal                      Show permissions in numeric octal format instead of symbolic
     --time <TIME>                Which kind of timestamp to use; modified by default [possible values: created, accessed, modified]
+    --time-format                Which format to use for the timestamp; default by default [possible values: iso, iso-strict, short, default]
 ```
 
 <p align="center">

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -97,6 +97,10 @@ pub struct Context {
     #[arg(long, value_enum, requires = "long")]
     pub time: Option<time::Stamp>,
 
+    #[cfg(unix)]
+    #[arg(long = "time-format", value_enum, requires = "long")]
+    pub time_format: Option<time::Format>,
+
     /// Maximum depth to display
     #[arg(short = 'L', long, value_name = "NUM")]
     level: Option<usize>,
@@ -317,6 +321,11 @@ impl Context {
     #[cfg(unix)]
     pub fn time(&self) -> time::Stamp {
         self.time.unwrap_or_default()
+    }
+
+    #[cfg(unix)]
+    pub fn time_format(&self) -> time::Format {
+        self.time_format.unwrap_or_default()
     }
 
     /// Which `FileType` to filter on; defaults to regular file.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -97,6 +97,7 @@ pub struct Context {
     #[arg(long, value_enum, requires = "long")]
     pub time: Option<time::Stamp>,
 
+    /// Which format to use for the timestamp; default by default
     #[cfg(unix)]
     #[arg(long = "time-format", value_enum, requires = "long")]
     pub time_format: Option<time::Format>,
@@ -323,6 +324,7 @@ impl Context {
         self.time.unwrap_or_default()
     }
 
+    /// Which format to use for the timestamp; default by default
     #[cfg(unix)]
     pub fn time_format(&self) -> time::Format {
         self.time_format.unwrap_or_default()

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -13,3 +13,15 @@ pub enum Stamp {
     #[default]
     Modified,
 }
+
+#[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum Format {
+    Iso,
+
+    IsoStrict,
+
+    Short,
+
+    #[default]
+    Default,
+}

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -14,14 +14,19 @@ pub enum Stamp {
     Modified,
 }
 
+/// Different formatting options for timestamps
 #[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum Format {
+    /// Timestamp formatted following the iso8601, with slight differences and the time-zone omitted
     Iso,
 
+    /// Timestamp formatted following the exact iso8601 specifications
     IsoStrict,
 
+    /// Timestamp only shows date without time in YYYY-MM-DD format
     Short,
 
+    /// Timestamp is shown in DD MMM HH:MM format
     #[default]
     Default,
 }

--- a/src/render/grid/cell.rs
+++ b/src/render/grid/cell.rs
@@ -206,6 +206,7 @@ impl<'a> Cell<'a> {
         write!(f, "{formatted_datetime}")
     }
 
+	/// Rules on how to format timestamp
     #[cfg(unix)]
     #[inline]
     fn fmt_timestamp(&self, dt: DateTime<Local>) -> String {


### PR DESCRIPTION
add support for specifying a format for timestamps (`--time-format`) in `--long` mode. the formats are inspired by [the git implementation](https://git-scm.com/docs/git-log#Documentation/git-log.txt---dateltformatgt).

i was unsure of what flag to use, but since you used `--time` over `--date`, and therefore `--time` was already taken by something else, i chose the more explicit `--time-format` flag.

i chose to add the formats `iso`, `iso-strict` and `short`, the latter two strictly following their implementation in git, with `iso` dropping the time zone specifier entirely (since the time zone is local-only anyway), but i made it so you should be able to easily expand to more options if needed.

the old format is still the default or can be explicitly specified with `--time-format default`. i would personally consider using the full year instead of only the last two digits, but that would mean recreating a good number of screenshots in the readme, so i didn't

i do not know rust well enough to know how or even if to best implement unit tests, so i did not.

say when you want me to change anything. ty.