### PR TITLE
support for user and group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "dirs",
+ "errno 0.3.1",
  "filesize",
  "ignore",
  "indextree",
@@ -253,13 +254,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -631,7 +632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
 dependencies = [
  "bitflags",
- "errno 0.3.0",
+ "errno 0.3.1",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.1",
@@ -942,6 +943,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ chrono = "0.4.24"
 clap = { version = "4.1.1", features = ["derive"] }
 clap_complete = "4.1.1"
 dirs = "5.0"
+errno = "0.3.1"
 filesize = "0.2.0"
 ignore = "0.4.2"
 indextree = "4.6.0"

--- a/src/context/column.rs
+++ b/src/context/column.rs
@@ -3,7 +3,7 @@ use std::convert::From;
 
 /// Utility struct to help store maximum column widths for attributes of each node. Each width is
 /// measured as the number of columns of the tty's window.
-pub struct ColumnProperties {
+pub struct Properties {
     pub max_size_width: usize,
     pub max_size_unit_width: usize,
 
@@ -15,9 +15,15 @@ pub struct ColumnProperties {
 
     #[cfg(unix)]
     pub max_block_width: usize,
+
+    #[cfg(unix)]
+    pub max_owner_width: usize,
+
+    #[cfg(unix)]
+    pub max_group_width: usize,
 }
 
-impl From<&Context> for ColumnProperties {
+impl From<&Context> for Properties {
     fn from(ctx: &Context) -> Self {
         let unit_width = match ctx.unit {
             PrefixKind::Bin if ctx.human => 3,
@@ -34,6 +40,10 @@ impl From<&Context> for ColumnProperties {
             max_ino_width: 0,
             #[cfg(unix)]
             max_block_width: 0,
+            #[cfg(unix)]
+            max_owner_width: 0,
+            #[cfg(unix)]
+            max_group_width: 0,
         }
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -86,6 +86,21 @@ pub struct Context {
     #[arg(short, long)]
     pub long: bool,
 
+    /// Show file's groups
+    #[cfg(unix)]
+    #[arg(long)]
+    pub group: bool,
+
+    /// Show each file's ino
+    #[cfg(unix)]
+    #[arg(long)]
+    pub ino: bool,
+
+    /// Show the total number of hardlinks to the underlying inode
+    #[cfg(unix)]
+    #[arg(long)]
+    pub nlink: bool,
+
     /// Show permissions in numeric octal format instead of symbolic
     #[cfg(unix)]
     #[arg(long, requires = "long")]
@@ -141,6 +156,10 @@ pub struct Context {
     #[arg(short, long, value_enum, default_value_t = PrefixKind::default())]
     pub unit: PrefixKind,
 
+    /// Which kind of layout to use when rendering the output
+    #[arg(short = 'y', long, value_enum, default_value_t = layout::Type::default())]
+    pub layout: layout::Type,
+
     /// Show hidden files
     #[arg(short = '.', long)]
     pub hidden: bool,
@@ -156,10 +175,6 @@ pub struct Context {
     /// Only print directories
     #[arg(long)]
     pub dirs_only: bool,
-
-    /// Which kind of layout to use when rendering the output
-    #[arg(long, value_enum, default_value_t = layout::Type::default())]
-    pub layout: layout::Type,
 
     /// Don't read configuration file
     #[arg(long)]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -7,7 +7,6 @@ use ignore::{
     overrides::{Override, OverrideBuilder},
     DirEntry,
 };
-use output::ColumnProperties;
 use regex::Regex;
 use std::{
     borrow::Borrow,
@@ -35,7 +34,7 @@ pub mod file;
 pub mod layout;
 
 /// Utilities to print output.
-pub mod output;
+pub mod column;
 
 /// Printing order kinds.
 pub mod sort;
@@ -207,6 +206,16 @@ pub struct Context {
     #[clap(skip = usize::default())]
     #[cfg(unix)]
     pub max_block_width: usize,
+
+    /// Restricts column width of file owner for long view
+    #[clap(skip = usize::default())]
+    #[cfg(unix)]
+    pub max_owner_width: usize,
+
+    /// Restricts column width of file group for long view
+    #[clap(skip = usize::default())]
+    #[cfg(unix)]
+    pub max_group_width: usize,
 
     /// Width of the terminal emulator's window
     #[clap(skip)]
@@ -486,12 +495,14 @@ impl Context {
     }
 
     /// Update column width properties.
-    pub fn update_column_properties(&mut self, col_props: &ColumnProperties) {
+    pub fn update_column_properties(&mut self, col_props: &column::Properties) {
         self.max_size_width = col_props.max_size_width;
         self.max_size_unit_width = col_props.max_size_unit_width;
 
         #[cfg(unix)]
         {
+            self.max_owner_width = col_props.max_owner_width;
+            self.max_group_width = col_props.max_group_width;
             self.max_nlink_width = col_props.max_nlink_width;
             self.max_block_width = col_props.max_block_width;
             self.max_ino_width = col_props.max_ino_width;

--- a/src/disk_usage/file_size/byte.rs
+++ b/src/disk_usage/file_size/byte.rs
@@ -45,7 +45,7 @@ impl Metric {
             human_readable,
             kind,
             prefix_kind,
-            cached_display: RefCell::default()
+            cached_display: RefCell::default(),
         }
     }
 
@@ -56,7 +56,7 @@ impl Metric {
             human_readable,
             kind: MetricKind::Logical,
             prefix_kind,
-            cached_display: RefCell::default()
+            cached_display: RefCell::default(),
         }
     }
 
@@ -67,7 +67,7 @@ impl Metric {
             human_readable,
             kind: MetricKind::Physical,
             prefix_kind,
-            cached_display: RefCell::default()
+            cached_display: RefCell::default(),
         }
     }
 
@@ -86,7 +86,7 @@ impl Metric {
             human_readable,
             kind,
             prefix_kind,
-            cached_display: RefCell::default()
+            cached_display: RefCell::default(),
         }
     }
 

--- a/src/disk_usage/file_size/byte.rs
+++ b/src/disk_usage/file_size/byte.rs
@@ -98,7 +98,7 @@ impl Display for Metric {
                 } else {
                     let base_value = unit.base_value();
                     let size = value / (base_value as f64);
-                    write!(f, "{size:.2} {unit}")
+                    write!(f, "{size:.1} {unit}")
                 }
             }
             PrefixKind::Bin => {
@@ -113,7 +113,7 @@ impl Display for Metric {
                 } else {
                     let base_value = unit.base_value();
                     let size = value / (base_value as f64);
-                    write!(f, "{size:.2} {unit}")
+                    write!(f, "{size:.1} {unit}")
                 }
             }
         }
@@ -136,7 +136,7 @@ fn test_metric() {
         human_readable: true,
         prefix_kind: PrefixKind::Si,
     };
-    assert_eq!(format!("{}", metric), "1.00 KB");
+    assert_eq!(format!("{}", metric), "1.0 KB");
 
     let metric = Metric {
         value: 1000,
@@ -152,7 +152,7 @@ fn test_metric() {
         human_readable: true,
         prefix_kind: PrefixKind::Bin,
     };
-    assert_eq!(format!("{}", metric), "1.00 KiB");
+    assert_eq!(format!("{}", metric), "1.0 KiB");
 
     let metric = Metric {
         value: 2_u64.pow(20),
@@ -160,7 +160,7 @@ fn test_metric() {
         human_readable: true,
         prefix_kind: PrefixKind::Bin,
     };
-    assert_eq!(format!("{}", metric), "1.00 MiB");
+    assert_eq!(format!("{}", metric), "1.0 MiB");
 
     let metric = Metric {
         value: 123454,

--- a/src/disk_usage/file_size/byte.rs
+++ b/src/disk_usage/file_size/byte.rs
@@ -91,7 +91,7 @@ impl Metric {
     }
 
     /// Returns an immutable borrow of the `cached_display`.
-    pub fn cached_display<'a>(&self) -> Ref<'_, String> {
+    pub fn cached_display(&self) -> Ref<'_, String> {
         self.cached_display.borrow()
     }
 }
@@ -110,9 +110,7 @@ impl Display for Metric {
 
         let display = match self.prefix_kind {
             PrefixKind::Si => {
-                if !self.human_readable {
-                    format!("{} {}", self.value, SiPrefix::Base)
-                } else {
+                if self.human_readable {
                     let unit = SiPrefix::from(self.value);
 
                     if matches!(unit, SiPrefix::Base) {
@@ -122,12 +120,12 @@ impl Display for Metric {
                         let size = value / (base_value as f64);
                         format!("{size:.1} {unit}")
                     }
+                } else {
+                    format!("{} {}", self.value, SiPrefix::Base)
                 }
             }
             PrefixKind::Bin => {
-                if !self.human_readable {
-                    format!("{} {}", self.value, BinPrefix::Base)
-                } else {
+                if self.human_readable {
                     let unit = BinPrefix::from(self.value);
 
                     if matches!(unit, BinPrefix::Base) {
@@ -137,13 +135,15 @@ impl Display for Metric {
                         let size = value / (base_value as f64);
                         format!("{size:.1} {unit}")
                     }
+                } else {
+                    format!("{} {}", self.value, BinPrefix::Base)
                 }
             }
         };
 
         write!(f, "{display}")?;
 
-        let _ = self.cached_display.replace(display);
+        self.cached_display.replace(display);
 
         Ok(())
     }

--- a/src/disk_usage/file_size/mod.rs
+++ b/src/disk_usage/file_size/mod.rs
@@ -19,6 +19,9 @@ pub mod line_count;
 /// Concerned with measuring file size by word count.
 pub mod word_count;
 
+#[cfg(unix)]
+pub const BLOCK_SIZE_BYTES: u16 = 512;
+
 /// Represents all the different ways in which a filesize could be reported using various metrics.
 pub enum FileSize {
     Word(word_count::Metric),

--- a/src/disk_usage/file_size/mod.rs
+++ b/src/disk_usage/file_size/mod.rs
@@ -1,6 +1,10 @@
 use crate::context::Context;
 use clap::ValueEnum;
-use std::{convert::From, ops::AddAssign};
+use std::{
+    convert::From,
+    fmt::{self, Display},
+    ops::AddAssign,
+};
 
 /// Concerned with measuring file size in blocks.
 #[cfg(unix)]
@@ -85,6 +89,19 @@ impl From<&Context> for FileSize {
 
             #[cfg(unix)]
             DiskUsage::Block => Self::Block(block::Metric::default()),
+        }
+    }
+}
+
+impl Display for FileSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Word(metric) => write!(f, "{metric}"),
+            Self::Line(metric) => write!(f, "{metric}"),
+            Self::Byte(metric) => write!(f, "{metric}"),
+
+            #[cfg(unix)]
+            Self::Block(metric) => write!(f, "{metric}"),
         }
     }
 }

--- a/src/disk_usage/file_size/mod.rs
+++ b/src/disk_usage/file_size/mod.rs
@@ -20,6 +20,7 @@ pub enum FileSize {
     Word(word_count::Metric),
     Line(line_count::Metric),
     Byte(byte::Metric),
+    #[cfg(unix)]
     Block(block::Metric),
 }
 

--- a/src/disk_usage/units.rs
+++ b/src/disk_usage/units.rs
@@ -35,6 +35,32 @@ pub enum SiPrefix {
     Tera,
 }
 
+impl SiPrefix {
+    /// Returns the human readable representation of the SI prefix.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Base => "B",
+            Self::Kilo => "KB",
+            Self::Mega => "MB",
+            Self::Giga => "GB",
+            Self::Tera => "TB",
+        }
+    }
+}
+
+impl BinPrefix {
+    /// Returns the human readable representation of the binary prefix.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Base => "B",
+            Self::Kibi => "KiB",
+            Self::Mebi => "MiB",
+            Self::Gibi => "GiB",
+            Self::Tebi => "TiB",
+        }
+    }
+}
+
 pub trait UnitPrefix {
     fn base_value(&self) -> u64;
 }
@@ -103,24 +129,12 @@ impl From<u64> for SiPrefix {
 
 impl Display for BinPrefix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Base => f.pad("B"),
-            Self::Kibi => f.pad("KiB"),
-            Self::Mebi => f.pad("MiB"),
-            Self::Gibi => f.pad("GiB"),
-            Self::Tebi => f.pad("TiB"),
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 
 impl Display for SiPrefix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Base => f.pad("B"),
-            Self::Kilo => f.pad("KB"),
-            Self::Mega => f.pad("MB"),
-            Self::Giga => f.pad("GB"),
-            Self::Tera => f.pad("TB"),
-        }
+        write!(f, "{}", self.as_str())
     }
 }

--- a/src/disk_usage/units.rs
+++ b/src/disk_usage/units.rs
@@ -37,7 +37,7 @@ pub enum SiPrefix {
 
 impl SiPrefix {
     /// Returns the human readable representation of the SI prefix.
-    pub fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &str {
         match self {
             Self::Base => "B",
             Self::Kilo => "KB",
@@ -50,7 +50,7 @@ impl SiPrefix {
 
 impl BinPrefix {
     /// Returns the human readable representation of the binary prefix.
-    pub fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &str {
         match self {
             Self::Base => "B",
             Self::Kibi => "KiB",

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -13,6 +13,7 @@ pub mod permissions;
 pub mod xattr;
 
 /// Concerned with determining group and owner of file.
+#[cfg(unix)]
 pub mod ug;
 
 /// Returns the path to the target of the soft link. Returns `None` if provided `dir_entry` isn't a

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -8,9 +8,12 @@ pub mod inode;
 #[cfg(unix)]
 pub mod permissions;
 
-#[cfg(unix)]
 /// Determining whether or not a file has extended attributes.
+#[cfg(unix)]
 pub mod xattr;
+
+/// Concerned with determining group and owner of file.
+pub mod ug;
 
 /// Returns the path to the target of the soft link. Returns `None` if provided `dir_entry` isn't a
 /// symlink.

--- a/src/fs/ug.rs
+++ b/src/fs/ug.rs
@@ -1,13 +1,8 @@
 use errno::{errno, set_errno, Errno};
-use std::{
-    ffi::CStr,
-    fs::Metadata,
-    os::unix::fs::MetadataExt,
-};
+use std::{ffi::CStr, fs::Metadata, os::unix::fs::MetadataExt};
 
 type Owner = String;
 type Group = String;
-
 
 impl UserGroupInfo for Metadata {}
 

--- a/src/fs/ug.rs
+++ b/src/fs/ug.rs
@@ -1,0 +1,89 @@
+use errno::{errno, set_errno, Errno};
+use ignore::DirEntry;
+use std::{convert::AsRef, ffi::CStr, mem, os::unix::ffi::OsStrExt, path::Path, ptr};
+
+impl UserGroupInfo for DirEntry {
+    fn path(&self) -> &Path {
+        self.path()
+    }
+}
+
+type Owner = String;
+type Group = String;
+
+/// Trait that allows for files to query their owner and group.
+pub trait UserGroupInfo {
+    fn path(&self) -> &Path;
+
+    /// Attemps to query the owner of the implementor.
+    fn try_get_owner(&self) -> Result<String, Errno> {
+        unsafe {
+            let libc::stat { st_uid, .. } = try_init_stat(self.path())?;
+            try_get_user(st_uid)
+        }
+    }
+
+    /// Attempts to query both the owner and group of the implementor.
+    fn try_get_owner_and_group(&self) -> Result<(Owner, Group), Errno> {
+        unsafe {
+            let libc::stat { st_uid, st_gid, .. } = try_init_stat(self.path())?;
+            let user = try_get_user(st_uid)?;
+            let group = try_get_group(st_gid)?;
+
+            Ok((user, group))
+        }
+    }
+}
+
+/// A wrapper around [`libc::stat`].
+unsafe fn try_init_stat<P: AsRef<Path>>(path: P) -> Result<libc::stat, Errno> {
+    let mut stat = mem::zeroed::<libc::stat>();
+
+    let stat_ptr = ptr::addr_of_mut!(stat);
+    let path_ptr = path
+        .as_ref()
+        .as_os_str()
+        .as_bytes()
+        .as_ptr()
+        .cast::<libc::c_char>();
+
+    if libc::stat(path_ptr, stat_ptr) == -1 {
+        return Err(errno());
+    }
+
+    Ok(stat)
+}
+
+/// Attempts to return the name of the group associated with `gid`.
+unsafe fn try_get_group(gid: libc::gid_t) -> Result<String, Errno> {
+    set_errno(Errno(0));
+
+    let group = libc::getgrgid(gid);
+
+    let errno = errno();
+
+    if errno.0 != 0 {
+        return Err(errno);
+    }
+
+    let libc::group { gr_name, .. } = *group;
+
+    Ok(CStr::from_ptr(gr_name).to_string_lossy().to_string())
+}
+
+/// Attempts to return the name of the user associated with `uid`.
+unsafe fn try_get_user(uid: libc::uid_t) -> Result<String, Errno> {
+    set_errno(Errno(0));
+
+    let pwd = libc::getpwuid(uid);
+
+    let errno = errno();
+
+    if errno.0 != 0 {
+        return Err(errno);
+    }
+
+    let libc::passwd { pw_name, .. } = *pwd;
+
+    Ok(CStr::from_ptr(pw_name).to_string_lossy().to_string())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@
 )]
 #![allow(
     clippy::struct_excessive_bools,
+    clippy::too_many_arguments,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation

--- a/src/render/grid/cell.rs
+++ b/src/render/grid/cell.rs
@@ -324,6 +324,7 @@ impl<'a> Cell<'a> {
         let max_size_width = ctx.max_size_width;
         let max_unit_width = ctx.max_size_unit_width;
         let out = format!("{metric}");
+
         let [size, unit]: [&str; 2] = out.split(' ').collect::<Vec<&str>>().try_into().unwrap();
 
         if ctx.no_color() {

--- a/src/render/grid/cell.rs
+++ b/src/render/grid/cell.rs
@@ -1,5 +1,5 @@
 use crate::{
-    context::{Context, time},
+    context::{time, Context},
     disk_usage::{
         file_size::{byte, DiskUsage, FileSize},
         units::PrefixKind,
@@ -216,7 +216,7 @@ impl<'a> Cell<'a> {
         write!(f, "{formatted_datetime}")
     }
 
-	/// Rules on how to format timestamp
+    /// Rules on how to format timestamp
     #[cfg(unix)]
     #[inline]
     fn fmt_timestamp(&self, dt: DateTime<Local>) -> String {
@@ -228,7 +228,7 @@ impl<'a> Cell<'a> {
             time::Format::Short => dt.format("%Y-%m-%d"),
         };
 
-        format!("{:>12}", delayed_format)
+        format!("{delayed_format:>12}")
     }
 
     /// Rules on how to format permissions for rendering

--- a/src/render/grid/mod.rs
+++ b/src/render/grid/mod.rs
@@ -48,13 +48,14 @@ impl Display for Row<'_, Tree> {
         );
 
         let row = if ctx.long {
-            let ino = Cell::new(node, ctx, cell::Kind::Ino);
+            //let ino = Cell::new(node, ctx, cell::Kind::Ino);
             let perms = Cell::new(node, ctx, cell::Kind::Permissions);
-            let nlink = Cell::new(node, ctx, cell::Kind::Nlink);
-            let blocks = Cell::new(node, ctx, cell::Kind::Blocks);
+            //let nlink = Cell::new(node, ctx, cell::Kind::Nlink);
+            //let blocks = Cell::new(node, ctx, cell::Kind::Blocks);
             let time = Cell::new(node, ctx, cell::Kind::Datetime);
 
-            format!("{ino} {perms} {nlink} {blocks} {time} {size} {name}")
+            //format!("{ino} {perms} {nlink} {blocks} {time} {size} {name}")
+            format!("{perms} {time} {size} {name}")
         } else {
             format!("{size} {name}")
         };
@@ -106,13 +107,14 @@ impl Display for Row<'_, Flat> {
         let path = Cell::new(node, ctx, cell::Kind::FilePath);
 
         let row = if ctx.long {
-            let ino = Cell::new(node, ctx, cell::Kind::Ino);
+            //let ino = Cell::new(node, ctx, cell::Kind::Ino);
             let perms = Cell::new(node, ctx, cell::Kind::Permissions);
-            let nlink = Cell::new(node, ctx, cell::Kind::Nlink);
-            let blocks = Cell::new(node, ctx, cell::Kind::Blocks);
+            //let nlink = Cell::new(node, ctx, cell::Kind::Nlink);
+            //let blocks = Cell::new(node, ctx, cell::Kind::Blocks);
             let time = Cell::new(node, ctx, cell::Kind::Datetime);
 
-            format!("{ino} {perms} {nlink} {blocks} {time} {size}   {path}")
+            //format!("{ino} {perms} {nlink} {blocks} {time} {size}   {path}")
+            format!("{perms} {time} {size}   {path}")
         } else {
             format!("{size}   {path}")
         };

--- a/src/render/grid/mod.rs
+++ b/src/render/grid/mod.rs
@@ -52,10 +52,12 @@ impl Display for Row<'_, Tree> {
             let perms = Cell::new(node, ctx, cell::Kind::Permissions);
             //let nlink = Cell::new(node, ctx, cell::Kind::Nlink);
             //let blocks = Cell::new(node, ctx, cell::Kind::Blocks);
+            let owner = Cell::new(node, ctx, cell::Kind::Owner);
+            let group = Cell::new(node, ctx, cell::Kind::Group);
             let time = Cell::new(node, ctx, cell::Kind::Datetime);
 
             //format!("{ino} {perms} {nlink} {blocks} {time} {size} {name}")
-            format!("{perms} {time} {size} {name}")
+            format!("{perms} {owner} {group} {time} {size} {name}")
         } else {
             format!("{size} {name}")
         };

--- a/src/render/grid/mod.rs
+++ b/src/render/grid/mod.rs
@@ -5,6 +5,9 @@ use std::{
     marker::PhantomData,
 };
 
+#[cfg(unix)]
+use super::long;
+
 /// Concerned with rules to construct and a single cell in a given row.
 pub mod cell;
 
@@ -48,18 +51,40 @@ impl Display for Row<'_, Tree> {
         );
 
         let row = if ctx.long {
-            //let ino = Cell::new(node, ctx, cell::Kind::Ino);
-            let perms = Cell::new(node, ctx, cell::Kind::Permissions);
-            //let nlink = Cell::new(node, ctx, cell::Kind::Nlink);
-            //let blocks = Cell::new(node, ctx, cell::Kind::Blocks);
-            let owner = Cell::new(node, ctx, cell::Kind::Owner);
-            let group = Cell::new(node, ctx, cell::Kind::Group);
-            let time = Cell::new(node, ctx, cell::Kind::Datetime);
+            let optionals = long::Optionals::from(ctx);
+            let long_display = long::Display::new(optionals, node, ctx);
 
-            //format!("{ino} {perms} {nlink} {blocks} {time} {size} {name}")
-            format!("{perms} {owner} {group} {time} {size} {name}")
+            format!("{long_display} {size} {name}")
         } else {
             format!("{size} {name}")
+        };
+
+        if ctx.truncate && ctx.window_width.is_some() {
+            let window_width = ctx.window_width.unwrap();
+            let out = <str as Escaped>::truncate(&row, window_width);
+            write!(f, "{out}")
+        } else {
+            write!(f, "{row}")
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Display for Row<'_, Flat> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let node = self.node;
+        let ctx = self.ctx;
+
+        let size = Cell::new(node, ctx, cell::Kind::FileSize);
+        let path = Cell::new(node, ctx, cell::Kind::FilePath);
+
+        let row = if ctx.long {
+            let optionals = long::Optionals::from(ctx);
+            let long_display = long::Display::new(optionals, node, ctx);
+
+            format!("{long_display} {size} {path}")
+        } else {
+            format!("{size} {path}")
         };
 
         if ctx.truncate && ctx.window_width.is_some() {
@@ -88,38 +113,6 @@ impl Display for Row<'_, Tree> {
         );
 
         let row = format!("{size} {name}");
-
-        if ctx.truncate && ctx.window_width.is_some() {
-            let window_width = ctx.window_width.unwrap();
-            let out = <str as Escaped>::truncate(&row, window_width);
-            write!(f, "{out}")
-        } else {
-            write!(f, "{row}")
-        }
-    }
-}
-
-#[cfg(unix)]
-impl Display for Row<'_, Flat> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let node = self.node;
-        let ctx = self.ctx;
-
-        let size = Cell::new(node, ctx, cell::Kind::FileSize);
-        let path = Cell::new(node, ctx, cell::Kind::FilePath);
-
-        let row = if ctx.long {
-            //let ino = Cell::new(node, ctx, cell::Kind::Ino);
-            let perms = Cell::new(node, ctx, cell::Kind::Permissions);
-            //let nlink = Cell::new(node, ctx, cell::Kind::Nlink);
-            //let blocks = Cell::new(node, ctx, cell::Kind::Blocks);
-            let time = Cell::new(node, ctx, cell::Kind::Datetime);
-
-            //format!("{ino} {perms} {nlink} {blocks} {time} {size}   {path}")
-            format!("{perms} {time} {size}   {path}")
-        } else {
-            format!("{size}   {path}")
-        };
 
         if ctx.truncate && ctx.window_width.is_some() {
             let window_width = ctx.window_width.unwrap();

--- a/src/render/long/mod.rs
+++ b/src/render/long/mod.rs
@@ -1,0 +1,138 @@
+use super::grid::cell::{self, Cell};
+use crate::{context::Context, tree::node::Node};
+use std::{convert::From, fmt};
+
+/// Concerned with displaying that actual attributes associated with the long view.
+pub struct Display<'a> {
+    node: &'a Node,
+    ctx: &'a Context,
+    optional: Optionals,
+}
+
+/// Optionals fields that are displayed when `--long` is specified. Each field is a boolean,
+/// specifying whether or not a particular field should be included in the output when the long
+/// view is enabled.
+pub struct Optionals {
+    #[allow(dead_code)]
+    perms: bool,
+    #[allow(dead_code)]
+    owner: bool,
+    group: bool,
+    ino: bool,
+    #[allow(dead_code)]
+    nlink: bool,
+    #[allow(dead_code)]
+    time: bool,
+}
+
+impl<'a> Display<'a> {
+    /// Constructor for [`Display`].
+    pub const fn new(optional: Optionals, node: &'a Node, ctx: &'a Context) -> Self {
+        Self {
+            node,
+            ctx,
+            optional,
+        }
+    }
+}
+
+/// Default implementation for [`Optionals`]. Fields that are `true` are the default fields that
+/// should display when the long view is enabled.
+impl Default for Optionals {
+    fn default() -> Self {
+        Self {
+            perms: true,
+            owner: true,
+            group: false,
+            ino: false,
+            nlink: false,
+            time: true,
+        }
+    }
+}
+
+impl fmt::Display for Display<'_> {
+    /// Formatting the attributes associated with the long view.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Optionals {
+            group, ino, nlink, ..
+        } = self.optional;
+        let node = self.node;
+        let ctx = self.ctx;
+
+        let perms = Cell::new(node, ctx, cell::Kind::Permissions);
+        let owner = Cell::new(node, ctx, cell::Kind::Owner);
+        let time = Cell::new(node, ctx, cell::Kind::Datetime);
+
+        match (group, ino, nlink) {
+            (false, false, false) => {
+                write!(f, "{perms} {owner} {time}")
+            }
+
+            (true, true, true) => {
+                let group_out = Cell::new(node, ctx, cell::Kind::Group);
+                let ino_out = Cell::new(node, ctx, cell::Kind::Ino);
+                let nlink_out = Cell::new(node, ctx, cell::Kind::Nlink);
+
+                write!(
+                    f,
+                    "{ino_out} {perms} {nlink_out} {owner} {group_out} {time}"
+                )
+            }
+
+            (true, false, false) => {
+                let group_out = Cell::new(node, ctx, cell::Kind::Group);
+
+                write!(f, "{perms} {owner} {group_out} {time}")
+            }
+
+            (true, true, false) => {
+                let group_out = Cell::new(node, ctx, cell::Kind::Group);
+                let ino_out = Cell::new(node, ctx, cell::Kind::Ino);
+
+                write!(f, "{ino_out} {perms} {owner} {group_out} {time}")
+            }
+
+            (false, false, true) => {
+                let nlink_out = Cell::new(node, ctx, cell::Kind::Nlink);
+
+                write!(f, "{perms} {nlink_out} {owner} {time}")
+            }
+
+            (true, false, true) => {
+                let group_out = Cell::new(node, ctx, cell::Kind::Group);
+                let nlink_out = Cell::new(node, ctx, cell::Kind::Nlink);
+
+                write!(f, "{perms} {nlink_out} {owner} {group_out} {time}")
+            }
+
+            (false, true, false) => {
+                let ino_out = Cell::new(node, ctx, cell::Kind::Ino);
+
+                write!(f, "{ino_out} {perms} {owner} {time}")
+            }
+
+            (false, true, true) => {
+                let ino_out = Cell::new(node, ctx, cell::Kind::Ino);
+                let nlink_out = Cell::new(node, ctx, cell::Kind::Nlink);
+
+                write!(f, "{ino_out} {perms} {nlink_out} {owner} {time}")
+            }
+        }
+    }
+}
+
+impl From<&Context> for Optionals {
+    fn from(ctx: &Context) -> Self {
+        let Context {
+            group, ino, nlink, ..
+        } = *ctx;
+
+        Self {
+            group,
+            ino,
+            nlink,
+            ..Self::default()
+        }
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -11,6 +11,10 @@ pub mod grid;
 /// output tree.
 pub mod theme;
 
+/// Concerned with how to construct the long output.
+#[cfg(unix)]
+pub mod long;
+
 /// The struct that is generic over T, which is generally expected to be a unit-struct that
 /// ultimately determines which variant to use for the output.
 pub struct Engine<T> {

--- a/src/styles/mod.rs
+++ b/src/styles/mod.rs
@@ -61,6 +61,14 @@ static PLACEHOLDER_STYLE: OnceCell<Style> = OnceCell::new();
 #[cfg(unix)]
 static INO_STYLE: OnceCell<Style> = OnceCell::new();
 
+/// Runtime evaluated static that contains style for the file owner string.
+#[cfg(unix)]
+static OWNER_STYLE: OnceCell<Style> = OnceCell::new();
+
+/// Runtime evaluated static that contains style for the file owner string.
+#[cfg(unix)]
+static GROUP_STYLE: OnceCell<Style> = OnceCell::new();
+
 /// Runtime evaluated static that contains style for number of hardlinks i.e. `nlink`.
 #[cfg(unix)]
 static NLINK_STYLE: OnceCell<Style> = OnceCell::new();
@@ -148,6 +156,20 @@ pub fn get_ino_style() -> Result<&'static Style, Error<'static>> {
     INO_STYLE.get().ok_or(Error::Uninitialized("INO_STYLE"))
 }
 
+/// Getter for [`OWNER_STYLE`]. Returns an error if not initialized.
+#[cfg(unix)]
+#[inline]
+pub fn get_owner_style() -> Result<&'static Style, Error<'static>> {
+    OWNER_STYLE.get().ok_or(Error::Uninitialized("OWNER_STYLE"))
+}
+
+/// Getter for [`GROUP_STYLE`]. Returns an error if not initialized.
+#[cfg(unix)]
+#[inline]
+pub fn get_group_style() -> Result<&'static Style, Error<'static>> {
+    GROUP_STYLE.get().ok_or(Error::Uninitialized("GROUP_STYLE"))
+}
+
 /// Getter for [`NLINK_STYLE`]. Returns an error if not initialized.
 #[cfg(unix)]
 #[inline]
@@ -230,6 +252,12 @@ fn init_themes_for_long_view() {
 
     let datetime_style = Color::Purple.bold();
     DATETIME_STYLE.set(datetime_style).unwrap();
+
+    let owner_style = Color::Cyan.bold();
+    OWNER_STYLE.set(owner_style).unwrap();
+
+    let group_style = Color::Green.bold();
+    GROUP_STYLE.set(group_style).unwrap();
 }
 
 /// Initializes all color themes.

--- a/src/styles/mod.rs
+++ b/src/styles/mod.rs
@@ -77,11 +77,6 @@ static NLINK_STYLE: OnceCell<Style> = OnceCell::new();
 #[cfg(unix)]
 static DATETIME_STYLE: OnceCell<Style> = OnceCell::new();
 
-/// Runtime evaluated static that contains style for number of blocks of a directory entry i.e.
-/// `blocks`.
-#[cfg(unix)]
-static BLOCK_STYLE: OnceCell<Style> = OnceCell::new();
-
 /// Map of the names box-drawing elements to their styled strings.
 pub type ThemesMap = HashMap<&'static str, String>;
 
@@ -177,13 +172,6 @@ pub fn get_nlink_style() -> Result<&'static Style, Error<'static>> {
     NLINK_STYLE.get().ok_or(Error::Uninitialized("NLINK_STYLE"))
 }
 
-/// Getter for [`BLOCK_STYLE`]. Returns an error if not initialized.
-#[cfg(unix)]
-#[inline]
-pub fn get_block_style() -> Result<&'static Style, Error<'static>> {
-    BLOCK_STYLE.get().ok_or(Error::Uninitialized("BLOCK_STYLE"))
-}
-
 /// Getter for [`DATETIME_STYLE`]. Returns an error if not initialized.
 #[cfg(unix)]
 #[inline]
@@ -246,9 +234,6 @@ fn init_themes_for_long_view() {
 
     let nlink_style = Color::Red.bold();
     NLINK_STYLE.set(nlink_style).unwrap();
-
-    let block_style = Color::White.bold();
-    BLOCK_STYLE.set(block_style).unwrap();
 
     let datetime_style = Color::Purple.bold();
     DATETIME_STYLE.set(datetime_style).unwrap();

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -311,7 +311,8 @@ impl Tree {
         if let Some(file_size) = node.file_size() {
             if ctx.human {
                 let out = format!("{file_size}");
-                let [size, unit]: [&str; 2] = out.split(' ').collect::<Vec<&str>>().try_into().unwrap();
+                let [size, unit]: [&str; 2] =
+                    out.split(' ').collect::<Vec<&str>>().try_into().unwrap();
 
                 let file_size_cols = size.len();
                 let file_size_unit_cols = unit.len();
@@ -381,7 +382,8 @@ impl Tree {
         if let Some(file_size) = node.file_size() {
             if ctx.human {
                 let out = format!("{file_size}");
-                let [size, unit]: [&str; 2] = out.split(' ').collect::<Vec<&str>>().try_into().unwrap();
+                let [size, unit]: [&str; 2] =
+                    out.split(' ').collect::<Vec<&str>>().try_into().unwrap();
 
                 let file_size_cols = size.len();
                 let file_size_unit_cols = unit.len();

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -305,36 +305,31 @@ impl Tree {
         count
     }
 
-    /// Updates [`ColumnProperties`] with provided [Node].
+    /// Updates [`column::Properties`] with provided [`Node`].
     #[cfg(unix)]
     fn update_column_properties(col_props: &mut column::Properties, node: &Node, ctx: &Context) {
         if let Some(file_size) = node.file_size() {
-            let file_size_cols = utils::num_integral(file_size.value());
+            if ctx.human {
+                let out = format!("{file_size}");
+                let [size, unit]: [&str; 2] = out.split(' ').collect::<Vec<&str>>().try_into().unwrap();
 
-            if file_size_cols > col_props.max_size_width {
-                col_props.max_size_width = file_size_cols;
-            }
+                let file_size_cols = size.len();
+                let file_size_unit_cols = unit.len();
 
-            match ctx.disk_usage {
-                DiskUsage::Logical | DiskUsage::Physical => {
-                    let unit_len = match ctx.unit {
-                        PrefixKind::Bin if ctx.human => match BinPrefix::from(file_size.value()) {
-                            BinPrefix::Base => 1,
-                            _ => 3,
-                        },
-                        PrefixKind::Si if ctx.human => match SiPrefix::from(file_size.value()) {
-                            SiPrefix::Base => 1,
-                            _ => 2,
-                        },
-                        _ => 1,
-                    };
-
-                    if unit_len > col_props.max_size_unit_width {
-                        col_props.max_size_unit_width = unit_len;
-                    }
+                if file_size_cols > col_props.max_size_width {
+                    col_props.max_size_width = file_size_cols;
                 }
-                DiskUsage::Line | DiskUsage::Word | DiskUsage::Block => (),
-            }
+
+                if file_size_unit_cols > col_props.max_size_unit_width {
+                    col_props.max_size_unit_width = file_size_unit_cols;
+                }
+            } else {
+                let file_size_cols = utils::num_integral(file_size.value());
+
+                if file_size_cols > col_props.max_size_width {
+                    col_props.max_size_width = file_size_cols;
+                }
+            };
         }
 
         if ctx.long {
@@ -384,32 +379,27 @@ impl Tree {
     #[cfg(not(unix))]
     fn update_column_properties(col_props: &mut column::Properties, node: &Node, ctx: &Context) {
         if let Some(file_size) = node.file_size() {
-            let file_size_cols = utils::num_integral(file_size.value());
+            if ctx.human {
+                let out = format!("{file_size}");
+                let [size, unit]: [&str; 2] = out.split(' ').collect::<Vec<&str>>().try_into().unwrap();
 
-            if file_size_cols > col_props.max_size_width {
-                col_props.max_size_width = file_size_cols;
-            }
+                let file_size_cols = size.len();
+                let file_size_unit_cols = unit.len();
 
-            match ctx.disk_usage {
-                DiskUsage::Logical | DiskUsage::Physical => {
-                    let unit_len = match ctx.unit {
-                        PrefixKind::Bin if ctx.human => match BinPrefix::from(file_size.value()) {
-                            BinPrefix::Base => 1,
-                            _ => 3,
-                        },
-                        PrefixKind::Si if ctx.human => match SiPrefix::from(file_size.value()) {
-                            SiPrefix::Base => 1,
-                            _ => 2,
-                        },
-                        _ => 1,
-                    };
-
-                    if unit_len > col_props.max_size_unit_width {
-                        col_props.max_size_unit_width = unit_len;
-                    }
+                if file_size_cols > col_props.max_size_width {
+                    col_props.max_size_width = file_size_cols;
                 }
-                _ => (),
-            }
+
+                if file_size_unit_cols > col_props.max_size_unit_width {
+                    col_props.max_size_unit_width = file_size_unit_cols;
+                }
+            } else {
+                let file_size_cols = utils::num_integral(file_size.value());
+
+                if file_size_cols > col_props.max_size_width {
+                    col_props.max_size_width = file_size_cols;
+                }
+            };
         }
     }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,9 +1,6 @@
 use crate::{
     context::{column, file, Context},
-    disk_usage::{
-        file_size::{DiskUsage, FileSize},
-        units::{BinPrefix, PrefixKind, SiPrefix},
-    },
+    disk_usage::file_size::FileSize,
     fs::inode::Inode,
     utils,
 };

--- a/src/tree/node/mod.rs
+++ b/src/tree/node/mod.rs
@@ -286,7 +286,7 @@ impl TryFrom<(DirEntry, &Context)> for Node {
 
         #[cfg(unix)]
         let unix_attrs = if ctx.long {
-            unix::Attrs::from(&dir_entry)
+            unix::Attrs::from((&metadata, &dir_entry))
         } else {
             unix::Attrs::default()
         };

--- a/src/tree/node/mod.rs
+++ b/src/tree/node/mod.rs
@@ -21,17 +21,14 @@ use std::{
 #[cfg(unix)]
 use crate::{
     disk_usage::file_size::block,
-    fs::{
-        permissions::{FileMode, SymbolicNotation},
-        ug::UserGroupInfo,
-        xattr::ExtendedAttr,
-    },
+    fs::permissions::{FileMode, SymbolicNotation},
 };
 
 /// Ordering and sorting rules for [Node].
 pub mod cmp;
 
 /// File attributes specific to Unix systems.
+#[cfg(unix)]
 pub mod unix;
 
 /// A node of [`Tree`] that can be created from a [`DirEntry`]. Any filesystem I/O and
@@ -200,6 +197,18 @@ impl Node {
     #[cfg(unix)]
     pub const fn has_xattrs(&self) -> bool {
         self.unix_attrs.has_xattrs
+    }
+
+    /// Returns the owner of the [`Node`].
+    #[cfg(unix)]
+    pub fn owner(&self) -> Option<&str> {
+        self.unix_attrs.owner()
+    }
+
+    /// Returns the group of the [`Node`].
+    #[cfg(unix)]
+    pub fn group(&self) -> Option<&str> {
+        self.unix_attrs.group()
     }
 
     /// Getter for [Node]'s style field.

--- a/src/tree/node/unix.rs
+++ b/src/tree/node/unix.rs
@@ -1,0 +1,35 @@
+use crate::fs::{ug::UserGroupInfo, xattr::ExtendedAttr};
+use ignore::DirEntry;
+use std::convert::From;
+
+/// File attributes that are optionally computed and specific to Unix-like systems.
+#[derive(Default)]
+pub struct Attrs {
+    pub has_xattrs: bool,
+    owner: Option<String>,
+    group: Option<String>,
+}
+
+impl Attrs {
+    /// Constructor for [`Attrs`].
+    pub fn new(has_xattrs: bool, owner: Option<String>, group: Option<String>) -> Self {
+        Self {
+            has_xattrs,
+            owner,
+            group,
+        }
+    }
+}
+
+/// Initializes a [`Attrs`] from a [`DirEntry`].
+impl From<&DirEntry> for Attrs {
+    fn from(entry: &DirEntry) -> Self {
+        let has_xattrs = entry.has_xattrs();
+
+        if let Ok((o, g)) = entry.try_get_owner_and_group() {
+            return Self::new(has_xattrs, Some(o), Some(g));
+        }
+
+        Self::new(has_xattrs, None, None)
+    }
+}

--- a/src/tree/node/unix.rs
+++ b/src/tree/node/unix.rs
@@ -12,12 +12,22 @@ pub struct Attrs {
 
 impl Attrs {
     /// Constructor for [`Attrs`].
-    pub fn new(has_xattrs: bool, owner: Option<String>, group: Option<String>) -> Self {
+    pub const fn new(has_xattrs: bool, owner: Option<String>, group: Option<String>) -> Self {
         Self {
             has_xattrs,
             owner,
             group,
         }
+    }
+
+    /// Returns the file owner.
+    pub fn owner(&self) -> Option<&str> {
+        self.owner.as_ref().map(|s| s.as_str())
+    }
+
+    /// Returns the file's group.
+    pub fn group(&self) -> Option<&str> {
+        self.group.as_ref().map(|s| s.as_str())
     }
 }
 

--- a/src/tree/node/unix.rs
+++ b/src/tree/node/unix.rs
@@ -1,6 +1,6 @@
 use crate::fs::{ug::UserGroupInfo, xattr::ExtendedAttr};
 use ignore::DirEntry;
-use std::convert::From;
+use std::{fs::Metadata, convert::From};
 
 /// File attributes that are optionally computed and specific to Unix-like systems.
 #[derive(Default)]
@@ -32,11 +32,11 @@ impl Attrs {
 }
 
 /// Initializes a [`Attrs`] from a [`DirEntry`].
-impl From<&DirEntry> for Attrs {
-    fn from(entry: &DirEntry) -> Self {
+impl From<(&Metadata, &DirEntry)> for Attrs {
+    fn from((md, entry): (&Metadata, &DirEntry)) -> Self {
         let has_xattrs = entry.has_xattrs();
 
-        if let Ok((o, g)) = entry.try_get_owner_and_group() {
+        if let Ok((o, g)) = md.try_get_owner_and_group() {
             return Self::new(has_xattrs, Some(o), Some(g));
         }
 

--- a/src/tree/node/unix.rs
+++ b/src/tree/node/unix.rs
@@ -1,6 +1,6 @@
 use crate::fs::{ug::UserGroupInfo, xattr::ExtendedAttr};
 use ignore::DirEntry;
-use std::{fs::Metadata, convert::From};
+use std::{convert::From, fs::Metadata};
 
 /// File attributes that are optionally computed and specific to Unix-like systems.
 #[derive(Default)]
@@ -22,12 +22,12 @@ impl Attrs {
 
     /// Returns the file owner.
     pub fn owner(&self) -> Option<&str> {
-        self.owner.as_ref().map(|s| s.as_str())
+        self.owner.as_deref()
     }
 
     /// Returns the file's group.
     pub fn group(&self) -> Option<&str> {
-        self.group.as_ref().map(|s| s.as_str())
+        self.group.as_deref()
     }
 }
 

--- a/tests/flat.rs
+++ b/tests/flat.rs
@@ -37,7 +37,7 @@ fn flat_human() {
  446   B   lipsum
  308   B   dream_cycle/polaris.txt
  308   B   dream_cycle
-1.21 KiB   data
+ 1.2 KiB   data
 
 3 directories, 6 files"
         )


### PR DESCRIPTION
### Changes:

- Default long view now includes permissions, owner, and modification time. `ino`, `nlinks`, and `group` are optional.
- Added support file file owner and group.
- Human readable byte metric is now 1-scale i.e. one digit after the decimal