### PR TITLE
Bug/empty dir

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -286,7 +286,12 @@ impl Context {
 
             ids = crate::utils::uniq(ids);
 
-            for id in ids.into_iter().filter(|&id| id != "Context") {
+            // HACK:
+            // Going to need to figure out how to handle this better.
+            for id in ids
+                .into_iter()
+                .filter(|&id| id != "Context" && id != "group" && id != "searching")
+            {
                 if id == "dir" {
                     if let Ok(Some(raw)) = user_args.try_get_raw(id) {
                         let raw_args = raw.map(OsStr::to_owned).collect::<Vec<OsString>>();
@@ -560,7 +565,7 @@ impl Context {
     }
 
     /// The default number of threads to use for disk-reads and parallel processing.
-    fn num_threads() -> usize {
+    const fn num_threads() -> usize {
         3
     }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    context::{column, file, Context},
+    context::{column, Context},
     disk_usage::file_size::FileSize,
     fs::inode::Inode,
     progress::{self, IndicatorHandle, Message},
@@ -164,7 +164,7 @@ impl Tree {
                     ctx,
                 );
 
-                if ctx.prune || ctx.file_type != Some(file::Type::Dir) {
+                if ctx.prune || ctx.pattern.is_some() {
                     Self::prune_directories(root_id, &mut tree);
                 }
 


### PR DESCRIPTION
Closes https://github.com/solidiquis/erdtree/issues/185

- Fixes issue where empty directories were automatically being filtered out despite not opting into `--prune`
- Fixes issue where searching via globs or regex doesn't work when user has a config file
- Adds exit codes to `erdtree`