### PR TITLE
Fix segmentation fault when invalid group or user

### DIFF
--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -1,9 +1,5 @@
 #![allow(clippy::module_name_repetitions)]
-use std::io::{
-    IsTerminal,
-    stdin,
-    stdout
-};
+use std::io::{stdin, stdout, IsTerminal};
 
 #[cfg(windows)]
 mod windows;


### PR DESCRIPTION
Closes https://github.com/solidiquis/erdtree/issues/189

When a user or group isn't valid `errno` doesn't get set which causes a null pointer dereference. This PR does a null pointer check and returns an error if user or group is invalid.