### PR TITLE
Suppress size performance

### DIFF
--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -438,6 +438,12 @@ impl TryFrom<&Context> for WalkParallel {
             .overrides(ctx.no_git_override()?)
             .threads(ctx.threads);
 
+        if ctx.suppress_size && ctx.level() == 1 {
+            builder
+                .max_depth(Some(1))
+                .threads(1);
+        }
+
         if ctx.pattern.is_some() {
             if ctx.glob || ctx.iglob {
                 builder.filter_entry(ctx.glob_predicate()?);

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -439,9 +439,7 @@ impl TryFrom<&Context> for WalkParallel {
             .threads(ctx.threads);
 
         if ctx.suppress_size && ctx.level() == 1 {
-            builder
-                .max_depth(Some(1))
-                .threads(1);
+            builder.max_depth(Some(1)).threads(1);
         }
 
         if ctx.pattern.is_some() {


### PR DESCRIPTION
Some folks like to use `erdtree` as an `ls` replacement but because `erdtree` always does a full-depth traversal when reading entries from either disk or cache it was quite slow to get the first depth level of directory entries even if directory size is suppressed.

This PR makes it such that `$ erd --suppress-size --level 1` only reads root's entries using only a single-thread (regardless of `-T, --threads`) so that results are available almost instantaneously.

