### PR TITLE
Time aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ Options:
           Which kind of timestamp to use; modified by default
 
           Possible values:
-          - create: Timestamp showing when the file was created
-          - access: Timestamp showing when the file was last accessed
-          - mod:    Timestamp showing when the file was last modified
+          - create: Time created (alias: ctime)
+          - access: Time last accessed (alias: atime)
+          - mod:    Time last modified (alias: mtime)
 
       --time-format <TIME_FORMAT>
           Which format to use for the timestamp; default by default
@@ -676,13 +676,13 @@ Currently only available on Unix-like platforms. Support for Windows is planned.
     --octal
       Show permissions in numeric octal format instead of symbolic
 
-    --time <TIME>
+  --time <TIME>
       Which kind of timestamp to use; modified by default
 
       Possible values:
-      - create: Timestamp showing when the file was created
-      - access: Timestamp showing when the file was last accessed
-      - mod:    Timestamp showing when the file was last modified
+      - create: Time created (alias: ctime)
+      - access: Time last accessed (alias: atime)
+      - mod:    Time last modified (alias: mtime)
 
     --time-format <TIME_FORMAT>
       Which format to use for the timestamp; default by default

--- a/src/context/time.rs
+++ b/src/context/time.rs
@@ -3,14 +3,17 @@ use clap::ValueEnum;
 /// Different types of timestamps available in long-view.
 #[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum Stamp {
-    /// Timestamp showing when the file was created.
+    /// Time created (alias: ctime)
+    #[value(alias("ctime"))]
     Create,
 
-    /// Timestamp showing when the file was last accessed.
+    /// Time last accessed (alias: atime)
+    #[value(alias("atime"))]
     Access,
 
-    /// Timestamp showing when the file was last modified.
+    /// Time last modified (alias: mtime)
     #[default]
+    #[value(alias("mtime"))]
     Mod,
 }
 


### PR DESCRIPTION
Added aliases for `--time` enums:

```
  --time <TIME>
      Which kind of timestamp to use; modified by default

      Possible values:
      - create: Time created (alias: ctime)
      - access: Time last accessed (alias: atime)
      - mod:    Time last modified (alias: mtime)
```
