### PR TITLE
Argument reconciliation trait

### DIFF
--- a/example/.erdtree.toml
+++ b/example/.erdtree.toml
@@ -18,6 +18,8 @@ human = true
 level = 1
 suppress-size = true
 long = true
+no-ignore = true
+hidden = true
 
 # How many lines of Rust are in this code base?
 [rs]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+match_block_trailing_comma = true

--- a/src/context/args.rs
+++ b/src/context/args.rs
@@ -1,0 +1,128 @@
+use super::{config, error::Error, Context};
+use clap::{
+    builder::ArgAction, parser::ValueSource, ArgMatches, Command, CommandFactory, FromArgMatches,
+};
+use std::{
+    ffi::{OsStr, OsString},
+    path::PathBuf,
+};
+
+/// Allows the implementor to compute [`ArgMatches`] that reonciles arguments from both the
+/// command-line as well as the config file that gets loaded.
+pub trait Reconciler: CommandFactory + FromArgMatches {
+
+    /// Loads in arguments from both the command-line as well as the config file and reconciles
+    /// identical arguments between the two using these rules:
+    /// 
+    /// 1. If no config file is present, use arguments strictly from the command-line.
+    /// 2. If an argument was provided via the CLI then override the argument from the config.
+    /// 3. If an argument is sourced from its default value because a user didn't provide it via
+    ///    the CLI, then select the argument from the config if it exists.
+    fn compute_args() -> Result<ArgMatches, Error> {
+        let cmd = Self::command().args_override_self(true);
+
+        let user_args = Command::clone(&cmd).get_matches();
+
+        if user_args.get_one::<bool>("no_config").is_some_and(|b| *b) {
+            return Ok(user_args);
+        }
+
+        let maybe_config_args = {
+            if let Some(rc) = load_rc_config_args() {
+                Some(rc)
+            } else {
+                let named_table = user_args.get_one::<String>("config");
+
+                load_toml_config_args(named_table.map(String::as_str))?
+            }
+        };
+
+        let Some(config_args) = maybe_config_args else {
+            return Ok(user_args);
+        };
+
+        let mut final_args = init_empty_args();
+
+        for arg in cmd.get_arguments() {
+            let arg_id = arg.get_id();
+            let id_str = arg_id.as_str();
+
+            if id_str == "dir" {
+                if let Some(dir) = user_args.try_get_one::<PathBuf>(id_str)? {
+                    final_args.push(OsString::from(dir));
+                }
+                continue;
+            }
+
+            let argument_source = user_args
+                .value_source(id_str)
+                .map_or(&config_args, |source| {
+                    if matches!(source, ValueSource::CommandLine) {
+                        &user_args
+                    } else {
+                        &config_args
+                    }
+                });
+
+            let Some(key) = arg.get_long().map(|l| format!("--{l}")).map(OsString::from) else {
+                continue
+            };
+
+            match arg.get_action() {
+                ArgAction::SetTrue => {
+                    if argument_source
+                        .try_get_one::<bool>(id_str)?
+                        .is_some_and(|b| *b)
+                    {
+                        final_args.push(key);
+                    };
+                }
+                ArgAction::SetFalse => continue,
+                _ => {
+                    let Ok(Some(raw)) = argument_source.try_get_raw(id_str) else {
+                        continue;
+                    };
+                    final_args.push(key);
+                    final_args.extend(raw.map(OsStr::to_os_string));
+                }
+            }
+        }
+
+        Ok(cmd.get_matches_from(final_args))
+    }
+}
+
+impl Reconciler for Context {}
+
+/// Creates a properly formatted `Vec<OsString>` that [`clap::Command`] would understand.
+#[inline]
+fn init_empty_args() -> Vec<OsString> {
+    vec![OsString::from("--")]
+}
+
+
+/// Loads an [`ArgMatches`] from `.erdtreerc`.
+#[inline]
+fn load_rc_config_args() -> Option<ArgMatches> {
+    if let Some(rc_config) = config::rc::read_config_to_string() {
+        let parsed_args = config::rc::parse(&rc_config);
+        let config_args = Context::command().get_matches_from(parsed_args);
+
+        return Some(config_args);
+    }
+
+    None
+}
+
+/// Loads an [`ArgMatches`] from `.erdtree.toml`.
+#[inline]
+fn load_toml_config_args(named_table: Option<&str>) -> Result<Option<ArgMatches>, Error> {
+    if let Ok(toml_config) = config::toml::load() {
+        let parsed_args = config::toml::parse(toml_config, named_table)?;
+        let config_args = Context::command().get_matches_from(parsed_args);
+
+        return Ok(Some(config_args));
+    }
+
+    Ok(None)
+}

--- a/src/context/args.rs
+++ b/src/context/args.rs
@@ -7,7 +7,7 @@ use std::{
     path::PathBuf,
 };
 
-/// Allows the implementor to compute [`ArgMatches`] that reonciles arguments from both the
+/// Allows the implementor to compute [`ArgMatches`] that reconciles arguments from both the
 /// command-line as well as the config file that gets loaded.
 pub trait Reconciler: CommandFactory + FromArgMatches {
 

--- a/src/context/args.rs
+++ b/src/context/args.rs
@@ -10,10 +10,9 @@ use std::{
 /// Allows the implementor to compute [`ArgMatches`] that reconciles arguments from both the
 /// command-line as well as the config file that gets loaded.
 pub trait Reconciler: CommandFactory + FromArgMatches {
-
     /// Loads in arguments from both the command-line as well as the config file and reconciles
     /// identical arguments between the two using these rules:
-    /// 
+    ///
     /// 1. If no config file is present, use arguments strictly from the command-line.
     /// 2. If an argument was provided via the CLI then override the argument from the config.
     /// 3. If an argument is sourced from its default value because a user didn't provide it via
@@ -76,7 +75,7 @@ pub trait Reconciler: CommandFactory + FromArgMatches {
                     {
                         final_args.push(key);
                     };
-                }
+                },
                 ArgAction::SetFalse => continue,
                 _ => {
                     let Ok(Some(raw)) = argument_source.try_get_raw(id_str) else {
@@ -84,7 +83,7 @@ pub trait Reconciler: CommandFactory + FromArgMatches {
                     };
                     final_args.push(key);
                     final_args.extend(raw.map(OsStr::to_os_string));
-                }
+                },
             }
         }
 
@@ -99,7 +98,6 @@ impl Reconciler for Context {}
 fn init_empty_args() -> Vec<OsString> {
     vec![OsString::from("--")]
 }
-
 
 /// Loads an [`ArgMatches`] from `.erdtreerc`.
 #[inline]

--- a/src/context/config/rc.rs
+++ b/src/context/config/rc.rs
@@ -1,6 +1,6 @@
 use std::{env, fs, path::PathBuf};
 
-/// Reads the config file into a `String` if there is one. When `None` is provided then the config
+/// Reads the config file into a `String` if there is one, otherwise returns `None`.
 /// is looked for in the following locations in order:
 ///
 /// - `$ERDTREE_CONFIG_PATH`

--- a/src/context/config/toml/mod.rs
+++ b/src/context/config/toml/mod.rs
@@ -24,13 +24,13 @@ enum ArgInstructions {
 }
 
 /// Takes in a `Config` that is generated from [`load`] returning a `Vec<OsString>` which
-/// represents command-line arguments from `.erdtree.toml`. If a `nested_table` is provided then
+/// represents command-line arguments from `.erdtree.toml`. If a `named_table` is provided then
 /// the top-level table in `.erdtree.toml` is ignored and the configurations specified in the
-/// `nested_table` will be used instead.
-pub fn parse(config: Config, nested_table: Option<&str>) -> Result<Vec<OsString>, Error> {
+/// `named_table` will be used instead.
+pub fn parse(config: Config, named_table: Option<&str>) -> Result<Vec<OsString>, Error> {
     let mut args_map = config.cache.into_table()?;
 
-    if let Some(table) = nested_table {
+    if let Some(table) = named_table {
         let new_conf = args_map
             .get(table)
             .and_then(|conf| conf.clone().into_table().ok())

--- a/src/context/config/toml/mod.rs
+++ b/src/context/config/toml/mod.rs
@@ -51,12 +51,12 @@ pub fn parse(config: Config, named_table: Option<&str>) -> Result<Vec<OsString>,
                 let fmt_key = process_key(k);
                 parsed_args.push(fmt_key);
                 parsed_args.push(parsed_value);
-            }
+            },
 
             ArgInstructions::PushKeyOnly => {
                 let fmt_key = process_key(k);
                 parsed_args.push(fmt_key);
-            }
+            },
 
             ArgInstructions::Pass => continue,
         }
@@ -110,7 +110,7 @@ fn parse_argument(keyword: &str, arg: &Value) -> Result<ArgInstructions, Error> 
             } else {
                 Ok(ArgInstructions::Pass)
             }
-        }
+        },
         ValueKind::String(val) => Ok(ArgInstructions::PushKeyValue {
             parsed_value: OsString::from(val),
         }),

--- a/src/context/error.rs
+++ b/src/context/error.rs
@@ -1,5 +1,5 @@
 use super::config::toml::error::Error as TomlError;
-use clap::Error as ClapError;
+use clap::{parser::MatchesError, Error as ClapError};
 use ignore::Error as IgnoreError;
 use regex::Error as RegexError;
 use std::convert::From;
@@ -26,6 +26,9 @@ pub enum Error {
 
     #[error("{0}")]
     ConfigError(TomlError),
+
+    #[error("{0}")]
+    MatchError(#[from] MatchesError),
 }
 
 impl From<TomlError> for Error {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,6 +1,7 @@
 use super::disk_usage::{file_size::DiskUsage, units::PrefixKind};
 use crate::tty;
-use clap::{parser::ValueSource, ArgMatches, CommandFactory, FromArgMatches, Parser};
+use args::Reconciler;
+use clap::{FromArgMatches, Parser};
 use color::Coloring;
 use error::Error;
 use ignore::{
@@ -11,11 +12,14 @@ use regex::Regex;
 use std::{
     borrow::Borrow,
     convert::From,
-    ffi::{OsStr, OsString},
     num::NonZeroUsize,
     path::{Path, PathBuf},
     thread::available_parallelism,
 };
+
+/// Concerned with figuring out how to reconcile arguments provided via the command-line with
+/// arguments that come from a config file.
+pub mod args;
 
 /// Operations to load in defaults from configuration file.
 pub mod config;
@@ -253,73 +257,8 @@ impl Context {
     /// Initializes [Context], optionally reading in the configuration file to override defaults.
     /// Arguments provided will take precedence over config.
     pub fn try_init() -> Result<Self, Error> {
-        // User-provided arguments from command-line.
-        let user_args = Self::command().args_override_self(true).get_matches();
-
-        // User provides `--no-config`.
-        if user_args.get_one::<bool>("no_config").is_some_and(|b| *b) {
-            return Self::from_arg_matches(&user_args).map_err(Error::ArgParse);
-        }
-
-        // Load in `.erdtreerc` or `.erdtree.toml`.
-        let config_args = if let Some(config) = config::rc::read_config_to_string() {
-            let raw_args = config::rc::parse(&config);
-
-            Self::command().get_matches_from(raw_args)
-        } else if let Ok(config) = config::toml::load() {
-            let named_table = user_args.get_one::<String>("config");
-            let raw_args = config::toml::parse(config, named_table.map(String::as_str))?;
-
-            Self::command().get_matches_from(raw_args)
-        } else {
-            return Self::from_arg_matches(&user_args).map_err(Error::ArgParse);
-        };
-
-        // If the user did not provide any arguments just read from config.
-        if !user_args.args_present() {
-            return Self::from_arg_matches(&config_args).map_err(Error::Config);
-        }
-
-        let mut args = vec![OsString::from("--")];
-
-        let ids = Self::command()
-            .get_arguments()
-            .map(|arg| arg.get_id().clone())
-            .collect::<Vec<_>>();
-
-        for id in ids {
-            let id_str = id.as_str();
-
-            if id_str == "dir" {
-                if let Ok(Some(dir)) = user_args.try_get_one::<PathBuf>(id_str) {
-                    args.push(dir.as_os_str().to_owned());
-                    continue;
-                }
-            }
-
-            let Some(source) = user_args.value_source(id_str) else {
-                if let Some(params) = Self::extract_args_from(id_str, &config_args) {
-                    args.extend(params);
-                }
-                continue;
-            };
-
-            let higher_precedent = match source {
-                // User provided argument takes precedent over argument from config
-                ValueSource::CommandLine => &user_args,
-
-                // otherwise prioritize argument from the config
-                _ => &config_args,
-            };
-
-            if let Some(params) = Self::extract_args_from(id_str, higher_precedent) {
-                args.extend(params);
-            }
-        }
-
-        let clargs = Self::command().get_matches_from(args);
-
-        Self::from_arg_matches(&clargs).map_err(Error::Config)
+        let args = Self::compute_args()?;
+        Self::from_arg_matches(&args).map_err(Error::Config)
     }
 
     /// Determines whether or not it's appropriate to display color in output based on
@@ -371,26 +310,6 @@ impl Context {
     /// Which `FileType` to filter on; defaults to regular file.
     pub fn file_type(&self) -> file::Type {
         self.file_type.unwrap_or_default()
-    }
-
-    /// Used to pick either from config or user args when constructing [Context].
-    #[inline]
-    fn extract_args_from(id: &str, matches: &ArgMatches) -> Option<Vec<OsString>> {
-        let Ok(Some(raw)) = matches.try_get_raw(id) else {
-            return None
-        };
-
-        let kebap = format!("--{}", id.replace('_', "-"));
-
-        let raw_args = raw
-            .map(OsStr::to_owned)
-            .map(|s| [OsString::from(&kebap), s])
-            .filter(|[_key, val]| val != "false")
-            .flatten()
-            .filter(|s| s != "true")
-            .collect::<Vec<_>>();
-
-        Some(raw_args)
     }
 
     /// Predicate used for filtering via regular expressions and file-type. When matching regular

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -347,11 +347,11 @@ impl Context {
                 match file_type {
                     file::Type::File if entry_type.map_or(true, |ft| !ft.is_file()) => {
                         return false
-                    }
+                    },
                     file::Type::Link if entry_type.map_or(true, |ft| !ft.is_symlink()) => {
                         return false
-                    }
-                    _ => {}
+                    },
+                    _ => {},
                 }
                 let file_name = dir_entry.file_name().to_string_lossy();
                 re.is_match(&file_name)
@@ -416,11 +416,11 @@ impl Context {
                 match file_type {
                     file::Type::File if entry_type.map_or(true, |ft| !ft.is_file()) => {
                         return false
-                    }
+                    },
                     file::Type::Link if entry_type.map_or(true, |ft| !ft.is_symlink()) => {
                         return false
-                    }
-                    _ => {}
+                    },
+                    _ => {},
                 }
 
                 let matched = overrides.matched(dir_entry.path(), false);

--- a/src/disk_usage/file_size/byte.rs
+++ b/src/disk_usage/file_size/byte.rs
@@ -123,7 +123,7 @@ impl Display for Metric {
                 } else {
                     format!("{} {}", self.value, SiPrefix::Base)
                 }
-            }
+            },
             PrefixKind::Bin => {
                 if self.human_readable {
                     let unit = BinPrefix::from(self.value);
@@ -138,7 +138,7 @@ impl Display for Metric {
                 } else {
                     format!("{} {}", self.value, BinPrefix::Base)
                 }
-            }
+            },
         };
 
         write!(f, "{display}")?;

--- a/src/icons/fs.rs
+++ b/src/icons/fs.rs
@@ -61,7 +61,7 @@ pub fn compute_with_color(
             let ansi_string: ANSIGenericString<str> = fg.bold().paint(icon);
             let styled_icon = ansi_string.to_string();
             Cow::from(styled_icon)
-        }
+        },
         _ => icon,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,19 +96,19 @@ fn run() -> Result<(), Box<dyn Error>> {
         layout::Type::Flat => {
             let render = Engine::<Flat>::new(tree, ctx);
             format!("{render}")
-        }
+        },
         layout::Type::Iflat => {
             let render = Engine::<FlatInverted>::new(tree, ctx);
             format!("{render}")
-        }
+        },
         layout::Type::Inverted => {
             let render = Engine::<Inverted>::new(tree, ctx);
             format!("{render}")
-        }
+        },
         layout::Type::Regular => {
             let render = Engine::<Regular>::new(tree, ctx);
             format!("{render}")
-        }
+        },
     };
 
     if let Some(progress) = indicator {

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,17 @@ fn run() -> Result<(), Box<dyn Error>> {
         progress.join_handle.join().unwrap()?;
     }
 
-    println!("{output}");
+    #[cfg(debug_assertions)]
+    {
+        if std::env::var_os("ERDTREE_DEBUG").is_none() {
+            println!("{output}");
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        println!("{output}");
+    }
 
     Ok(())
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -107,8 +107,8 @@ impl<'a> Indicator<'a> {
                         Message::Index => indicator.index()?,
                         Message::DoneIndexing => {
                             indicator.update_state(IndicatorState::Rendering)?;
-                        }
-                        Message::RenderReady => {}
+                        },
+                        Message::RenderReady => {},
                     }
                 }
 
@@ -137,14 +137,14 @@ impl<'a> Indicator<'a> {
                 stdout.execute(terminal::Clear(ClearType::CurrentLine))?;
                 stdout.execute(cursor::RestorePosition)?;
                 self.rendering();
-            }
+            },
 
             (Rendering, Done) => {
                 let stdout = &mut self.stdout;
                 stdout.execute(terminal::Clear(ClearType::CurrentLine))?;
                 stdout.execute(cursor::RestorePosition)?;
                 stdout.execute(cursor::Show)?;
-            }
+            },
             _ => (),
         }
 

--- a/src/render/grid/cell.rs
+++ b/src/render/grid/cell.rs
@@ -79,7 +79,7 @@ impl<'a> Cell<'a> {
                 let icon = node.compute_icon(ctx.no_color());
 
                 write!(f, "{pre}{icon} {name}")
-            }
+            },
 
             _ => unreachable!(),
         }
@@ -319,11 +319,11 @@ impl<'a> Cell<'a> {
                 PrefixKind::Si => {
                     let pre = SiPrefix::from(metric.value);
                     styles::get_du_theme().unwrap().get(pre.as_str()).unwrap()
-                }
+                },
                 PrefixKind::Bin => {
                     let pre = BinPrefix::from(metric.value);
                     styles::get_du_theme().unwrap().get(pre.as_str()).unwrap()
-                }
+                },
             }
         };
 
@@ -351,11 +351,11 @@ impl<'a> Cell<'a> {
             PrefixKind::Si => {
                 let pre = SiPrefix::from(bytes);
                 styles::get_du_theme().unwrap().get(pre.as_str()).unwrap()
-            }
+            },
             PrefixKind::Bin => {
                 let pre = BinPrefix::from(bytes);
                 styles::get_du_theme().unwrap().get(pre.as_str()).unwrap()
-            }
+            },
         };
 
         let out = color.paint(format!("{metric:>max_size_width$}"));

--- a/src/render/layout/regular.rs
+++ b/src/render/layout/regular.rs
@@ -50,7 +50,7 @@ impl Display for Engine<Regular> {
                     }
 
                     continue;
-                }
+                },
             };
 
             file_count_data.push(Tree::compute_file_count(current_node_id, arena));

--- a/src/render/long/mod.rs
+++ b/src/render/long/mod.rs
@@ -67,7 +67,7 @@ impl fmt::Display for Display<'_> {
         match (group, ino, nlink) {
             (false, false, false) => {
                 write!(f, "{perms} {owner} {time}")
-            }
+            },
 
             (true, true, true) => {
                 let group_out = Cell::new(node, ctx, cell::Kind::Group);
@@ -78,46 +78,46 @@ impl fmt::Display for Display<'_> {
                     f,
                     "{ino_out} {perms} {nlink_out} {owner} {group_out} {time}"
                 )
-            }
+            },
 
             (true, false, false) => {
                 let group_out = Cell::new(node, ctx, cell::Kind::Group);
 
                 write!(f, "{perms} {owner} {group_out} {time}")
-            }
+            },
 
             (true, true, false) => {
                 let group_out = Cell::new(node, ctx, cell::Kind::Group);
                 let ino_out = Cell::new(node, ctx, cell::Kind::Ino);
 
                 write!(f, "{ino_out} {perms} {owner} {group_out} {time}")
-            }
+            },
 
             (false, false, true) => {
                 let nlink_out = Cell::new(node, ctx, cell::Kind::Nlink);
 
                 write!(f, "{perms} {nlink_out} {owner} {time}")
-            }
+            },
 
             (true, false, true) => {
                 let group_out = Cell::new(node, ctx, cell::Kind::Group);
                 let nlink_out = Cell::new(node, ctx, cell::Kind::Nlink);
 
                 write!(f, "{perms} {nlink_out} {owner} {group_out} {time}")
-            }
+            },
 
             (false, true, false) => {
                 let ino_out = Cell::new(node, ctx, cell::Kind::Ino);
 
                 write!(f, "{ino_out} {perms} {owner} {time}")
-            }
+            },
 
             (false, true, true) => {
                 let ino_out = Cell::new(node, ctx, cell::Kind::Ino);
                 let nlink_out = Cell::new(node, ctx, cell::Kind::Nlink);
 
                 write!(f, "{ino_out} {perms} {nlink_out} {owner} {time}")
-            }
+            },
         }
     }
 }

--- a/src/tree/node/cmp.rs
+++ b/src/tree/node/cmp.rs
@@ -12,10 +12,10 @@ pub fn comparator(ctx: &Context) -> Box<NodeComparator> {
     match ctx.dir_order {
         dir::Order::First => {
             Box::new(move |a, b| dir_first_comparator(a, b, base_comparator(sort_type)))
-        }
+        },
         dir::Order::Last => {
             Box::new(move |a, b| dir_last_comparator(a, b, base_comparator(sort_type)))
-        }
+        },
         dir::Order::None => base_comparator(sort_type),
     }
 }

--- a/src/tree/node/mod.rs
+++ b/src/tree/node/mod.rs
@@ -256,28 +256,28 @@ impl TryFrom<(DirEntry, &Context)> for Node {
                     DiskUsage::Logical => {
                         let metric = byte::Metric::init_logical(&metadata, ctx.unit, ctx.human);
                         Some(FileSize::Byte(metric))
-                    }
+                    },
                     DiskUsage::Physical => {
                         let metric =
                             byte::Metric::init_physical(path, &metadata, ctx.unit, ctx.human);
                         Some(FileSize::Byte(metric))
-                    }
+                    },
                     DiskUsage::Line => {
                         let metric = line_count::Metric::init(path);
                         metric.map(FileSize::Line)
-                    }
+                    },
                     DiskUsage::Word => {
                         let metric = word_count::Metric::init(path);
                         metric.map(FileSize::Word)
-                    }
+                    },
 
                     #[cfg(unix)]
                     DiskUsage::Block => {
                         let metric = block::Metric::init(&metadata);
                         Some(FileSize::Block(metric))
-                    }
+                    },
                 }
-            }
+            },
             _ => None,
         };
 

--- a/src/tree/visitor.rs
+++ b/src/tree/visitor.rs
@@ -46,7 +46,7 @@ impl ParallelVisitor for Branch<'_> {
             Ok(node) => {
                 self.tx.send(TraversalState::from(node)).unwrap();
                 WalkState::Continue
-            }
+            },
             _ => WalkState::Skip,
         }
     }


### PR DESCRIPTION
Removes some dirty hacks that supported the use of a config file.

Logic that reconciles arguments between the CLI and a potential config file has now been moved over into a trait with more rigorous argument processing as to remove hacks and make things less error prone.