### PR TITLE
ensure global .gitignore to sync with git_ignore flag

### DIFF
--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -435,6 +435,7 @@ impl TryFrom<&Context> for WalkParallel {
         builder
             .follow_links(ctx.follow)
             .git_ignore(!ctx.no_ignore)
+            .git_global(!ctx.no_ignore)
             .hidden(!ctx.hidden)
             .overrides(ctx.no_git_override()?)
             .same_file_system(ctx.same_fs)


### PR DESCRIPTION
#208 
### -i, --no-ignore 
- Do not respect .gitignore **...and global .gitignore files**

**Change Summary**
- The issue is due to the presence of a global .gitignore file; the symlink was just the victim by chance. Currently, globally ignored files will continue to be removed regardless of flag: -i, --no-ignore. Syncing both global and local .gitignores better addresses the user request.

**Change to Code**
- specifying git_global() method with ignore context to WalkBuilder struct to match the (-i, --no-ignore) flag's use case. 
