### PR TITLE
Display config file formatting errors

### DIFF
--- a/src/context/args.rs
+++ b/src/context/args.rs
@@ -121,10 +121,9 @@ fn load_rc_config_args() -> Option<ArgMatches> {
 /// Loads an [`ArgMatches`] from `.erdtree.toml`.
 #[inline]
 fn load_toml_config_args(named_table: Option<&str>) -> Result<Option<ArgMatches>, Error> {
-    config::toml::load().map_or(Ok(None), |toml_config| {
-        let parsed_args = config::toml::parse(toml_config, named_table)?;
-        let config_args = Context::command().get_matches_from(parsed_args);
+    let toml_config = config::toml::load()?;
+    let parsed_args = config::toml::parse(toml_config, named_table)?;
+    let config_args = Context::command().get_matches_from(parsed_args);
 
-        Ok(Some(config_args))
-    })
+    Ok(Some(config_args))
 }

--- a/src/context/config/toml/error.rs
+++ b/src/context/config/toml/error.rs
@@ -5,7 +5,7 @@ pub enum Error {
     #[error("Failed to load .erdtree.toml")]
     LoadConfig,
 
-    #[error("The configuration file is improperly formatted")]
+    #[error("The configuration file is improperly formatted: {0}")]
     InvalidFormat(#[from] ConfigError),
 
     #[error("Named table '{0}' was not found in '.erdtree.toml'")]


### PR DESCRIPTION
I noticed that syntax errors in the TOML config file would result in a "file not found" style error message which can be rather confusing. So here's a proposal to change that.