### PR TITLE
Allow `erdtree` to be used as an extern crate

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -58,7 +58,7 @@ pub mod time;
 #[command(about = "erdtree (erd) is a cross-platform, multi-threaded, and general purpose filesystem and disk usage utility.", long_about = None)]
 pub struct Context {
     /// Directory to traverse; defaults to current working directory
-    dir: Option<PathBuf>,
+    pub dir: Option<PathBuf>,
 
     /// Use configuration of named table rather than the top-level table in .erdtree.toml
     #[arg(short = 'c', long)]
@@ -125,7 +125,7 @@ pub struct Context {
 
     /// Maximum depth to display
     #[arg(short = 'L', long, value_name = "NUM")]
-    level: Option<usize>,
+    pub level: Option<usize>,
 
     /// Regular expression (or glob if '--glob' or '--iglob' is used) used to match files
     #[arg(short, long)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,35 @@
+pub use context::Context;
+
+/// Operations to wrangle ANSI escaped strings.
+pub mod ansi;
+
+/// CLI rules and definitions as well as context to be injected throughout the entire program.
+pub mod context;
+
+/// Operations relevant to the computation and presentation of disk usage.
+pub mod disk_usage;
+
+/// Filesystem operations.
+pub mod fs;
+
+/// All things related to icons on how to map certain files to the appropriate icons.
+pub mod icons;
+
+/// Concerned with displaying a progress indicator when stdout is a tty.
+pub mod progress;
+
+/// Concerned with taking an initialized [`tree::Tree`] and its [`tree::node::Node`]s and rendering the output.
+pub mod render;
+
+/// Global used throughout the program to paint the output.
+pub mod styles;
+
+/// Houses the primary data structures that are used to virtualize the filesystem, containing also
+/// information on how the tree output should be ultimately rendered.
+pub mod tree;
+
+/// Utilities relating to interacting with tty properties.
+pub mod tty;
+
+/// Common utilities across all pub modules.
+pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,39 +23,7 @@ use std::{
 };
 use tree::Tree;
 
-/// Operations to wrangle ANSI escaped strings.
-mod ansi;
-
-/// CLI rules and definitions as well as context to be injected throughout the entire program.
-mod context;
-
-/// Operations relevant to the computation and presentation of disk usage.
-mod disk_usage;
-
-/// Filesystem operations.
-mod fs;
-
-/// All things related to icons on how to map certain files to the appropriate icons.
-mod icons;
-
-/// Concerned with displaying a progress indicator when stdout is a tty.
-mod progress;
-
-/// Concerned with taking an initialized [`tree::Tree`] and its [`tree::node::Node`]s and rendering the output.
-mod render;
-
-/// Global used throughout the program to paint the output.
-mod styles;
-
-/// Houses the primary data structures that are used to virtualize the filesystem, containing also
-/// information on how the tree output should be ultimately rendered.
-mod tree;
-
-/// Utilities relating to interacting with tty properties.
-mod tty;
-
-/// Common utilities across all modules.
-mod utils;
+use erdtree::*;
 
 fn main() -> ExitCode {
     if let Err(e) = run() {


### PR DESCRIPTION
This PR allows people to use `cargo add erdtree` and then be able to use `erdtree` as a library.