### PR TITLE
Improve performance when using `--long`

### DIFF
--- a/src/tree/node/mod.rs
+++ b/src/tree/node/mod.rs
@@ -272,7 +272,9 @@ impl TryFrom<(DirEntry, &Context)> for Node {
         let inode = Inode::try_from(&metadata).ok();
 
         #[cfg(unix)]
-        let unix_attrs = if ctx.long {
+        let unix_attrs = if ctx.long
+            && path.components().count() <= ctx.dir_canonical().components().count().saturating_add(ctx.level())
+        {
             unix::Attrs::from((&metadata, &dir_entry))
         } else {
             unix::Attrs::default()


### PR DESCRIPTION
Previously, the unix extended attributes are always read no matter what. This is maybe not ideal, as it is very expensive to call for files which we will not display and leads to significantly (~300x with level = 2) worse runtimes recursing large directories. This is fixed by only calling `unix::Attrs::from` when it is a file which is going to be displayed.

This is my first PR here, so if I've missed anything please let me know.

# Rough benchmarks
These are run with the path being my home directory, which consists of (per `erd`) 11650 directories, 124225 files, and 132 links. The command run is `time erd -l --no-config -L 2 ~` for both cases, and all times are averaged over 5 runs.

## Before
| Executed in | 81.01 secs |
|:-----------------:|:---------------:|
| usr time       | 10.83 secs |
| sys time       | 15.58 secs |

## After
| Executed in | 0.24 secs   |
|:-----------------:|:---------------:|
| usr time       | 0.56 secs   |
| sys time       | 0.47 secs   |